### PR TITLE
FRW-9368 Enabled locale switching test for demo shops.

### DIFF
--- a/cypress/e2e/yves/core/locale-switching.cy.ts
+++ b/cypress/e2e/yves/core/locale-switching.cy.ts
@@ -4,55 +4,54 @@ import { CatalogPage, HomePage } from '@pages/yves';
 import { LocaleStaticFixtures } from '@interfaces/yves';
 
 describe('locale switching', { tags: ['@core', '@yves'] }, (): void => {
-    const homePage = container.get(HomePage);
-    const catalogPage = container.get(CatalogPage);
-    const localeSwitchingScenario = container.get(LocaleSwitchingScenario);
+  const homePage = container.get(HomePage);
+  const catalogPage = container.get(CatalogPage);
+  const localeSwitchingScenario = container.get(LocaleSwitchingScenario);
 
-    let staticFixtures: LocaleStaticFixtures;
+  let staticFixtures: LocaleStaticFixtures;
 
-    before((): void => {
-      ({ staticFixtures } = Cypress.env());
+  before((): void => {
+    ({ staticFixtures } = Cypress.env());
+  });
+
+  /**
+   * Helper method for testing locale switching on any page.
+   * @param visitPage - Function to visit the page (e.g., `catalogPage.visit`).
+   * @param page - The page object containing methods like `getAvailableLocales`.
+   */
+  const testLocaleSwitching = (visitPage: () => void, page: { getAvailableLocales: () => void }): void => {
+    visitPage();
+
+    page.getAvailableLocales();
+
+    localeSwitchingScenario.execute({
+      currentLocale: staticFixtures.localeEN,
+      selectedLocale: staticFixtures.localeDE,
     });
 
-    /**
-     * Helper method for testing locale switching on any page.
-     * @param visitPage - Function to visit the page (e.g., `catalogPage.visit`).
-     * @param page - The page object containing methods like `getAvailableLocales`.
-     */
-    const testLocaleSwitching = (visitPage: () => void, page: { getAvailableLocales: () => void }): void => {
-      visitPage();
-
-      page.getAvailableLocales();
-
-      localeSwitchingScenario.execute({
-        currentLocale: staticFixtures.localeEN,
-        selectedLocale: staticFixtures.localeDE,
-      });
-
-      cy.reload();
-      localeSwitchingScenario.execute({
-        currentLocale: staticFixtures.localeDE,
-        selectedLocale: staticFixtures.localeEN,
-      });
-    };
-
-    skipDisabledDynamicStoreIt('should be able to switch locales at the home page.', (): void => {
-      testLocaleSwitching(() => homePage.visit(), homePage);
+    cy.reload();
+    localeSwitchingScenario.execute({
+      currentLocale: staticFixtures.localeDE,
+      selectedLocale: staticFixtures.localeEN,
     });
+  };
 
-    it('should be able to switch locales at the catalog page.', (): void => {
-      testLocaleSwitching(() => catalogPage.visit(), catalogPage);
-    });
+  skipDisabledDynamicStoreIt('should be able to switch locales at the home page.', (): void => {
+    testLocaleSwitching(() => homePage.visit(), homePage);
+  });
 
-    it('should be able to switch locales at the product detailed page.', (): void => {
-      testLocaleSwitching(() => {
-        catalogPage.visit();
-        catalogPage.goToFirstItemInCatalogPage();
-      }, catalogPage);
-    });
+  it('should be able to switch locales at the catalog page.', (): void => {
+    testLocaleSwitching(() => catalogPage.visit(), catalogPage);
+  });
 
-    function skipDisabledDynamicStoreIt(description: string, testFn: () => void): void {
-      (Cypress.env('isDynamicStoreEnabled') ? it : it.skip)(description, testFn);
-    }
+  it('should be able to switch locales at the product detailed page.', (): void => {
+    testLocaleSwitching(() => {
+      catalogPage.visit();
+      catalogPage.goToFirstItemInCatalogPage();
+    }, catalogPage);
+  });
+
+  function skipDisabledDynamicStoreIt(description: string, testFn: () => void): void {
+    (Cypress.env('isDynamicStoreEnabled') ? it : it.skip)(description, testFn);
   }
-);
+});

--- a/cypress/e2e/yves/core/locale-switching.cy.ts
+++ b/cypress/e2e/yves/core/locale-switching.cy.ts
@@ -3,10 +3,7 @@ import { LocaleSwitchingScenario } from '@scenarios/yves';
 import { CatalogPage, HomePage } from '@pages/yves';
 import { LocaleStaticFixtures } from '@interfaces/yves';
 
-(['b2c', 'b2c-mp', 'b2b', 'b2b-mp'].includes(Cypress.env('repositoryId')) ? describe.skip : describe)(
-  'locale switching',
-  { tags: ['@core', '@yves'] },
-  (): void => {
+describe('locale switching', { tags: ['@core', '@yves'] }, (): void => {
     const homePage = container.get(HomePage);
     const catalogPage = container.get(CatalogPage);
     const localeSwitchingScenario = container.get(LocaleSwitchingScenario);


### PR DESCRIPTION
- Developer(s): @aleksandr-velikanov

- Ticket: https://spryker.atlassian.net/browse/FRW-9368

##### Note

- This enables the Locale Switching Cypress test for demo shops (it was disabled initially until the FRW-9368 changes were integrated)
