### PR TITLE
SSP-824 Yves access level filtering and search consolidation.

### DIFF
--- a/cypress/e2e/yves/ssp-asset/ssp-asset.cy.ts
+++ b/cypress/e2e/yves/ssp-asset/ssp-asset.cy.ts
@@ -218,9 +218,6 @@ import { CustomerLoginScenario, CheckoutScenario } from '@scenarios/yves';
         assetListPage.openFilters();
       }
 
-      assetListPage
-        .getAccessTableFilterSelect()
-        .select(assetListPage.getAccessTableFilterByBusinessUnitValue(), { force: true });
       assetListPage.getSspAssetFiltersSubmitButton().click();
 
       assetListPage.assertTableData([dynamicFixtures.assetBU1C1BU2C1BU1C2, dynamicFixtures.assetBU1C1]);

--- a/cypress/e2e/yves/ssp-file-management/ssp-file-management.cy.ts
+++ b/cypress/e2e/yves/ssp-file-management/ssp-file-management.cy.ts
@@ -242,7 +242,7 @@ describeForSsp('File Manager Module - Files List', { tags: ['@backoffice', '@fil
     sspFileManagementListPage.filterByBusinessEntity(dynamicFixtures.businessUnit2C1.uuid.toString());
     sspFileManagementListPage.filterBySspAssetEntity('none');
     sspFileManagementListPage.applyFilters();
-    sspFileManagementListPage.assertFileNotExists(dynamicFixtures.file1.file_name);
+    sspFileManagementListPage.assertFileExists(dynamicFixtures.file1.file_name);
     sspFileManagementListPage.assertFileExists(dynamicFixtures.file2.file_name);
     sspFileManagementListPage.assertFileNotExists(dynamicFixtures.file3.file_name);
     sspFileManagementListPage.assertFileNotExists(dynamicFixtures.fileSspAsset1.file_name);

--- a/cypress/e2e/yves/ssp-inquiry/ssp-inquiry.cy.ts
+++ b/cypress/e2e/yves/ssp-inquiry/ssp-inquiry.cy.ts
@@ -316,6 +316,7 @@ import { CustomerLogoutScenario } from '@scenarios/yves';
 
       sspInquiryListPage.visit();
       sspInquiryListPage.assertPageLocation();
+      sspInquiryListPage.submitSspInquirySearchForm();
       sspInquiryListPage.assetPageHasNoSspInquiries();
     });
 

--- a/cypress/support/pages/yves/ssp-asset/ssp-asset-list-page.ts
+++ b/cypress/support/pages/yves/ssp-asset/ssp-asset-list-page.ts
@@ -59,10 +59,6 @@ export class SspAssetListPage extends YvesPage {
     return this.repository.getSspAssetFiltersSubmitButton();
   }
 
-  getAccessTableFilterByBusinessUnitValue(): string {
-    return 'filterByBusinessUnit';
-  }
-
   getAccessTableFilterByCompanyValue(): string {
     return 'filterByCompany';
   }

--- a/cypress/support/pages/yves/ssp-inquiry/repositories/b2b-mp-ssp-inquiry-repository.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/repositories/b2b-mp-ssp-inquiry-repository.ts
@@ -14,6 +14,8 @@ export class B2bMpSspInquiryRepository implements SspInquiryRepository {
     descriptionTextarea: 'textarea[name="sspInquiryForm[description]"]',
     fileInput: 'input[name="sspInquiryForm[files][]"]',
     submitButton: 'button[type="submit"]',
+    sspInquirySearchForm: 'form[name="sspInquirySearchForm"]',
+    sspInquirySearchFormSubmitButton: '[data-qa="submit-filters"]',
   };
 
   getCreateGeneralSspInquiryButton(): Cypress.Chainable {
@@ -149,5 +151,13 @@ export class B2bMpSspInquiryRepository implements SspInquiryRepository {
 
   getFileDownloadActionSelector(): string {
     return '[data-qa*="download-button"]';
+  }
+
+  getSspInquirySearchForm(): Cypress.Chainable {
+    return cy.get(this.selectors.sspInquirySearchForm);
+  }
+
+  getSspInquirySearchFormSubmitButton(): Cypress.Chainable {
+    return cy.get(this.selectors.sspInquirySearchFormSubmitButton);
   }
 }

--- a/cypress/support/pages/yves/ssp-inquiry/repositories/b2b-ssp-inquiry-repository.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/repositories/b2b-ssp-inquiry-repository.ts
@@ -14,6 +14,8 @@ export class B2bSspInquiryRepository implements SspInquiryRepository {
     descriptionTextarea: 'textarea[name="sspInquiryForm[description]"]',
     fileInput: 'input[name="sspInquiryForm[files][]"]',
     submitButton: 'button[type="submit"]',
+    sspInquirySearchForm: 'form[name="sspInquirySearchForm"]',
+    sspInquirySearchFormSubmitButton: '[data-qa="submit-filters"]',
   };
 
   getCreateGeneralSspInquiryButton(): Cypress.Chainable {
@@ -149,5 +151,13 @@ export class B2bSspInquiryRepository implements SspInquiryRepository {
 
   getFileDownloadActionSelector(): string {
     return '[data-qa*="download-button"]';
+  }
+
+  getSspInquirySearchForm(): Cypress.Chainable {
+    return cy.get(this.selectors.sspInquirySearchForm);
+  }
+
+  getSspInquirySearchFormSubmitButton(): Cypress.Chainable {
+    return cy.get(this.selectors.sspInquirySearchFormSubmitButton);
   }
 }

--- a/cypress/support/pages/yves/ssp-inquiry/repositories/suite-ssp-inquiry-repository.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/repositories/suite-ssp-inquiry-repository.ts
@@ -14,6 +14,8 @@ export class SuiteSspInquiryRepository implements SspInquiryRepository {
     descriptionTextarea: 'textarea[name="sspInquiryForm[description]"]',
     fileInput: 'input[name="sspInquiryForm[files][]"]',
     submitButton: 'button[type="submit"]',
+    sspInquirySearchForm: 'form[name="sspInquirySearchForm"]',
+    sspInquirySearchFormSubmitButton: '[data-qa="submit-filters"]',
   };
 
   getCreateGeneralSspInquiryButton(): Cypress.Chainable {
@@ -149,5 +151,13 @@ export class SuiteSspInquiryRepository implements SspInquiryRepository {
 
   getFileDownloadActionSelector(): string {
     return '[data-qa*="download-button"]';
+  }
+
+  getSspInquirySearchForm(): Cypress.Chainable {
+    return cy.get(this.selectors.sspInquirySearchForm);
+  }
+
+  getSspInquirySearchFormSubmitButton(): Cypress.Chainable {
+    return cy.get(this.selectors.sspInquirySearchFormSubmitButton);
   }
 }

--- a/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-create-page.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-create-page.ts
@@ -21,10 +21,12 @@ export class SspInquiryCreatePage extends YvesPage {
   }
 
   createSspInquiry(params: SspInquiryParams): void {
-    this.repository.getTypeOptions().should('have.length', params.availableTypes.length);
-    params.availableTypes.forEach((type, index) => {
-      this.repository.getTypeOptions().eq(index).should('have.value', type.key);
-    });
+    if (params.availableTypes) {
+      this.repository.getTypeOptions().should('have.length', params.availableTypes.length);
+      params.availableTypes.forEach((type, index) => {
+        this.repository.getTypeOptions().eq(index).should('have.value', type.key);
+      });
+    }
 
     this.repository.getSubjectInput().type(params.subject);
     this.repository.getDescriptionTextarea().type(params.description);

--- a/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-list-page.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-list-page.ts
@@ -31,4 +31,8 @@ export class SspInquiryListPage extends YvesPage {
   getFirstRowReference(): string {
     return this.repository.getFirstRowReference();
   }
+
+  submitSspInquirySearchForm(): void {
+    this.repository.getSspInquirySearchFormSubmitButton().click();
+  }
 }

--- a/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-repository.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-repository.ts
@@ -29,4 +29,6 @@ export interface SspInquiryRepository {
   getFileInput(): Cypress.Chainable;
   getSubmitButton(): Cypress.Chainable;
   getFileDownloadActionSelector(): string;
+  getSspInquirySearchForm(): Cypress.Chainable;
+  getSspInquirySearchFormSubmitButton(): Cypress.Chainable;
 }


### PR DESCRIPTION
## PR Description

Ticket: https://spryker.atlassian.net/browse/SSP-824

This pull request introduces several improvements and fixes to the SSP asset and inquiry Cypress test suites, mainly focused on enhancing filter functionality and repository interfaces. The most important changes include adding support for submitting inquiry search forms, updating selectors in repository classes, and correcting test assertions related to file existence.

**Inquiry Search Form Enhancements:**

* Added new selectors (`sspInquirySearchForm`, `sspInquirySearchFormSubmitButton`) to all `SspInquiryRepository` implementations (`B2bMpSspInquiryRepository`, `B2bSspInquiryRepository`, `SuiteSspInquiryRepository`) and updated the `SspInquiryRepository` interface to support searching inquiries via form submission. [[1]](diffhunk://#diff-62ae0d904049656ba4aeaad68b2352d24f4bc3d6dcfc1e6b7664eadaa4e7b19bR17-R18) [[2]](diffhunk://#diff-62ae0d904049656ba4aeaad68b2352d24f4bc3d6dcfc1e6b7664eadaa4e7b19bR155-R162) [[3]](diffhunk://#diff-f7540e06c59e0854cf20e0ca6b014208050394b217ed71d919863b6ed0fde878R17-R18) [[4]](diffhunk://#diff-f7540e06c59e0854cf20e0ca6b014208050394b217ed71d919863b6ed0fde878R155-R162) [[5]](diffhunk://#diff-e2275467d9e1ae9b5a0a26d74e8d6423ebe97c1d6e21bd2d93c38ad42560cdb4R17-R18) [[6]](diffhunk://#diff-e2275467d9e1ae9b5a0a26d74e8d6423ebe97c1d6e21bd2d93c38ad42560cdb4R155-R162) [[7]](diffhunk://#diff-c589e78e5ba5c3a93a72ffdd861d5e7ddadbc01d30de4efd8b0b1090cb5b2d90R32-R33)
* Added a new method `submitSspInquirySearchForm()` to `SspInquiryListPage` and used it in the test to submit the inquiry search form before asserting that there are no inquiries. [[1]](diffhunk://#diff-3fdf0c2b2524703751d8fe28cf598321e44467dfa16db9730f6f41b90b2e77ddR34-R37) [[2]](diffhunk://#diff-157697be348de0c510aa994b5ee408cd4ea9c1be6b676a8f2f99c4f2b188fa35R319)

**Asset and File Management Test Updates:**

* Removed the business unit filter selection from the asset list test, simplifying the filter interaction before submitting.
* Corrected a file existence assertion in the file management test to check for the presence of `file1` instead of its absence.

**Repository and Page Object Improvements:**

* Removed the unused `getAccessTableFilterByBusinessUnitValue()` method from `SspAssetListPage` to clean up the page object.
* Updated `SspInquiryCreatePage.createSspInquiry()` to conditionally check available types only if provided, improving flexibility in inquiry creation tests.

## Steps before you submit a PR

- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
  `I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/cypress-tests/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist

- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
