### PR TITLE
SSP-824: Force click on SSP inquiry search form submit button.

### DIFF
--- a/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-list-page.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-list-page.ts
@@ -33,6 +33,6 @@ export class SspInquiryListPage extends YvesPage {
   }
 
   submitSspInquirySearchForm(): void {
-    this.repository.getSspInquirySearchFormSubmitButton().click();
+    this.repository.getSspInquirySearchFormSubmitButton().click({ force: true });
   }
 }


### PR DESCRIPTION
## PR Description

Ticket: https://spryker.atlassian.net/browse/SSP-824

This pull request makes a small update to the behavior of the SSP Inquiry search form submission in the `SspInquiryListPage` class. The change ensures that the search form's submit button is always clicked, even if it is not interactable due to visibility or other Cypress restrictions.

* The `submitSspInquirySearchForm` method now clicks the submit button using `{ force: true }`, guaranteeing the click action regardless of the button's state.

## Steps before you submit a PR

- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
  `I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/cypress-tests/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist

- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
