### PR TITLE
Extend wait time for environment stabilization

### DIFF
--- a/.github/workflows/post-deploy-workflow.yml
+++ b/.github/workflows/post-deploy-workflow.yml
@@ -43,7 +43,7 @@ jobs:
         run: composer require spryker/cypress-tests:dev-master
 
       - name: Wait for Environment to Stabilize (P&S and Jenkins processing)
-        run: sleep 300
+        run: sleep 1800
 
       - name: Execute Post-Deploy-e2e Tests
         run: |


### PR DESCRIPTION
Increased wait time for environment stabilization from 5 to 30 minutes.

## PR Description

Add a meaningful description here that will let us know what you want to fix with this PR or what functionality you want to add.

## Steps before you submit a PR

- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
  `I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/cypress-tests/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist

- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
