### PR TITLE
Homepage select store fix

### DIFF
--- a/cypress/support/pages/yves/home/home-page.ts
+++ b/cypress/support/pages/yves/home/home-page.ts
@@ -22,8 +22,14 @@ export class HomePage extends YvesPage {
   };
 
   selectStore = (store: string): void => {
-    this.repository.selectStore(store);
-    cy.url().should('include', `${store}`);
+    // Cypress does not fire the 'change' event when the option is already selected,
+    // so window.location never gets set. Read the store URL from the option value directly.
+    cy.get(this.repository.getStoreSelectorOption(store))
+      .invoke('val')
+      .then((storeUrl) => {
+        cy.visit(storeUrl as string);
+      });
+    cy.url().should('include', store);
   };
 
   navigateToNewPage(newPageLinkText: string): void {


### PR DESCRIPTION
## PR Description

As an example - order-management/order-creation-dms.cy.ts
We expect to check TEST store functionality, but if for any reason we already have TEST store, the test always fails

The dropdown with stores does not allow store switch to test if we are already on the test store
At the same time, the test would fail if URL is not contain TEST_STORE part

So, this fix will trigger a locale switch even in this case
