### PR TITLE
CC-39159 Fix hasStore precondition idempotency

### DIFF
--- a/cypress/support/pages/backoffice/store/list/store-list-page.ts
+++ b/cypress/support/pages/backoffice/store/list/store-list-page.ts
@@ -29,11 +29,18 @@ export class StoreListPage extends BackofficePage {
   };
 
   hasStore = (storeName: string): Cypress.Chainable<boolean> => {
-    // Existence check only: register the intercept before typing and match on the
-    // exact search value so we wait for the full-search response (not a partial
-    // keystroke). Pass no expectedCount — never assert a band on a precondition.
+    // Existence check only — read the real row count, never assert a band on a precondition.
+
+    // Unique name for the request we want to wait on. cy.wait('@alias') below targets a
+    // request by this name, so a fresh id keeps us from clashing with another table
+    // intercept or a stale alias left by a previous retry of this hook.
     const searchInterceptAlias = this.faker.string.uuid();
+
     cy.intercept('GET', '/store-gui/list/table**', (req) => {
+      // The field fires two table requests: an empty one when cleared, then one with the
+      // full value once typing settles (the search is debounced — not one per keystroke).
+      // Tag ONLY the full-store-name request so cy.wait() resolves on the real search
+      // result, not the empty clear.
       if (req.query['search[value]'] === storeName) {
         req.alias = searchInterceptAlias;
       }

--- a/cypress/support/pages/backoffice/store/list/store-list-page.ts
+++ b/cypress/support/pages/backoffice/store/list/store-list-page.ts
@@ -29,17 +29,24 @@ export class StoreListPage extends BackofficePage {
   };
 
   hasStore = (storeName: string): Cypress.Chainable<boolean> => {
+    // Existence check only: register the intercept before typing and match on the
+    // exact search value so we wait for the full-search response (not a partial
+    // keystroke). Pass no expectedCount — never assert a band on a precondition.
+    const searchInterceptAlias = this.faker.string.uuid();
+    cy.intercept('GET', '/store-gui/list/table**', (req) => {
+      if (req.query['search[value]'] === storeName) {
+        req.alias = searchInterceptAlias;
+      }
+    });
+
     const searchSelector = this.repository.getSearchSelector();
     cy.get(searchSelector).clear();
     cy.get(searchSelector).type(storeName);
 
-    return this.interceptTable({ url: '/store-gui/list/table**', expectedCount: 0 }).then((recordsFiltered: number) => {
-      if (recordsFiltered > 0) {
-        return cy.wrap(true);
-      } else {
-        return cy.wrap(false);
-      }
-    });
+    return cy
+      .wait(`@${searchInterceptAlias}`, { timeout: 10000 })
+      .its('response.body')
+      .then((body) => cy.wrap(body.recordsFiltered > 0));
   };
 }
 


### PR DESCRIPTION
## Summary
- `hasStore` compared interceptTable's resolved body object `> 0`, so it always returned `false` — `CreateStoreScenario` re-created the store and re-ran publish-and-sync on every retry. With the `expectedCount: 0` band check this threw in the before-each hook on retry 3, skipping the whole suite.
- Read the real `recordsFiltered` count and drop the band assertion on this precondition existence check. Register the intercept before typing and match on `search[value] === storeName` so we wait for the full-search response.

Jira: https://spryker.atlassian.net/browse/CC-39159

## Test Plan
- [x] customer-auth-dms spec with retries (docker): before-each no longer throws on attempt 3
- [x] publish-and-sync (`runQueueWorker`) fires once, not per attempt
- [x] No regression in store-create / CMS-block flows