### PR TITLE
CC-39159 Wait for MFA login to settle before navigating

### DIFF
--- a/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
@@ -18,6 +18,10 @@ export class AgentMfaLoginScenario {
       this.mfaPage.verifyCode(code);
     });
 
+    // verifyCode() submits the verification popup via fetch, so Cypress does not wait for a page
+    // load and the in-flight POST may not have established the MFA-passed session yet. Block until
+    // the redirect off the login page lands, otherwise the next visit() races that request and the
+    // agent guard bounces it back to /agent/login.
     cy.url({ timeout: 20000 }).should('not.include', '/agent/login');
   }
 

--- a/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
@@ -9,43 +9,20 @@ export class AgentMfaLoginScenario {
   @inject(AgentMultiFactorAuthPage) private mfaPage: AgentMultiFactorAuthPage;
 
   execute(credentials: LoginCredentials): void {
-    cy.intercept('POST', '**/multi-factor-auth/send-user-code').as('mfaCodeSubmit');
-
     this.loginPage.visit();
     this.loginPage.login(credentials);
 
     this.mfaPage.waitForVerificationPopup();
 
-    this.submitNewestCode(credentials.username);
+    cy.intercept('POST', '**/multi-factor-auth/send-user-code').as('mfaCodeValidation');
 
-    // After a successful verification the popup reloads the page; wait for the redirect off the
-    // login page to land so the next visit() does not race the just-established session.
-    cy.url({ timeout: 20000 }).should('not.include', '/agent/login');
-  }
-
-  /**
-   * While it initialises, the login MFA popup requests a fresh verification code and can do so more
-   * than once. The backend keeps every code but only accepts the most recently generated one, so the
-   * first code read from the DB may already be stale by the time it is submitted — which left the
-   * test stuck on /agent/login. A rejected submit re-renders the validation form without issuing a
-   * new code, so re-reading the (now stable) newest code and submitting again succeeds. Bounded to
-   * stay within the backend attempt limit.
-   */
-  private submitNewestCode(username: string, attempt = 1): void {
-    const maxAttempts = 3;
-
-    cy.getUserMultiFactorAuthCode(username, 'email').then((code) => {
+    cy.getUserMultiFactorAuthCode(credentials.username, 'email').then((code) => {
       this.mfaPage.verifyCode(code);
     });
 
-    cy.wait('@mfaCodeSubmit').then((interception) => {
-      const body = interception.response?.body;
-      const verified = typeof body === 'string' && body.includes('data-success');
-
-      if (!verified && attempt < maxAttempts) {
-        this.submitNewestCode(username, attempt + 1);
-      }
-    });
+    // Wait for verification to succeed (session upgraded server-side) before the caller navigates,
+    // otherwise the test races the post-MFA login and lands back on /agent/login.
+    cy.wait('@mfaCodeValidation').its('response.body').should('include', 'data-success');
   }
 
   executeWithInvalidCode(credentials: LoginCredentials, staticFixtures: AgentMfaAuthStaticFixtures): void {

--- a/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
@@ -17,6 +17,8 @@ export class AgentMfaLoginScenario {
     cy.getUserMultiFactorAuthCode(credentials.username, 'email').then((code) => {
       this.mfaPage.verifyCode(code);
     });
+
+    cy.url({ timeout: 20000 }).should('not.include', '/agent/login');
   }
 
   executeWithInvalidCode(credentials: LoginCredentials, staticFixtures: AgentMfaAuthStaticFixtures): void {

--- a/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/agent-mfa-login-scenario.ts
@@ -9,20 +9,43 @@ export class AgentMfaLoginScenario {
   @inject(AgentMultiFactorAuthPage) private mfaPage: AgentMultiFactorAuthPage;
 
   execute(credentials: LoginCredentials): void {
+    cy.intercept('POST', '**/multi-factor-auth/send-user-code').as('mfaCodeSubmit');
+
     this.loginPage.visit();
     this.loginPage.login(credentials);
 
     this.mfaPage.waitForVerificationPopup();
 
-    cy.getUserMultiFactorAuthCode(credentials.username, 'email').then((code) => {
+    this.submitNewestCode(credentials.username);
+
+    // After a successful verification the popup reloads the page; wait for the redirect off the
+    // login page to land so the next visit() does not race the just-established session.
+    cy.url({ timeout: 20000 }).should('not.include', '/agent/login');
+  }
+
+  /**
+   * While it initialises, the login MFA popup requests a fresh verification code and can do so more
+   * than once. The backend keeps every code but only accepts the most recently generated one, so the
+   * first code read from the DB may already be stale by the time it is submitted — which left the
+   * test stuck on /agent/login. A rejected submit re-renders the validation form without issuing a
+   * new code, so re-reading the (now stable) newest code and submitting again succeeds. Bounded to
+   * stay within the backend attempt limit.
+   */
+  private submitNewestCode(username: string, attempt = 1): void {
+    const maxAttempts = 3;
+
+    cy.getUserMultiFactorAuthCode(username, 'email').then((code) => {
       this.mfaPage.verifyCode(code);
     });
 
-    // verifyCode() submits the verification popup via fetch, so Cypress does not wait for a page
-    // load and the in-flight POST may not have established the MFA-passed session yet. Block until
-    // the redirect off the login page lands, otherwise the next visit() races that request and the
-    // agent guard bounces it back to /agent/login.
-    cy.url({ timeout: 20000 }).should('not.include', '/agent/login');
+    cy.wait('@mfaCodeSubmit').then((interception) => {
+      const body = interception.response?.body;
+      const verified = typeof body === 'string' && body.includes('data-success');
+
+      if (!verified && attempt < maxAttempts) {
+        this.submitNewestCode(username, attempt + 1);
+      }
+    });
   }
 
   executeWithInvalidCode(credentials: LoginCredentials, staticFixtures: AgentMfaAuthStaticFixtures): void {

--- a/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
@@ -9,20 +9,43 @@ export class CustomerMfaLoginScenario {
   @inject(MultiFactorAuthPage) private mfaPage: MultiFactorAuthPage;
 
   execute(credentials: LoginCredentials): void {
+    cy.intercept('POST', '**/multi-factor-auth/send-user-code').as('mfaCodeSubmit');
+
     this.loginPage.visit();
     this.loginPage.login(credentials);
 
     this.mfaPage.waitForVerificationPopup();
 
-    cy.getMultiFactorAuthCode(credentials.email, 'email').then((code) => {
+    this.submitNewestCode(credentials.email);
+
+    // After a successful verification the popup reloads the page; wait for the redirect off the
+    // login page to land so the next visit() does not race the just-established session.
+    cy.url({ timeout: 20000 }).should('not.include', '/login');
+  }
+
+  /**
+   * While it initialises, the login MFA popup requests a fresh verification code and can do so more
+   * than once. The backend keeps every code but only accepts the most recently generated one, so the
+   * first code read from the DB may already be stale by the time it is submitted — which left the
+   * test stuck on /login. A rejected submit re-renders the validation form without issuing a new
+   * code, so re-reading the (now stable) newest code and submitting again succeeds. Bounded to stay
+   * within the backend attempt limit.
+   */
+  private submitNewestCode(email: string, attempt = 1): void {
+    const maxAttempts = 3;
+
+    cy.getMultiFactorAuthCode(email, 'email').then((code) => {
       this.mfaPage.verifyCode(code);
     });
 
-    // verifyCode() submits the verification popup via fetch, so Cypress does not wait for a page
-    // load and the in-flight POST may not have established the MFA-passed session yet. Block until
-    // the redirect off the login page lands, otherwise the next visit() races that request and the
-    // customer guard bounces it back to /login.
-    cy.url({ timeout: 20000 }).should('not.include', '/login');
+    cy.wait('@mfaCodeSubmit').then((interception) => {
+      const body = interception.response?.body;
+      const verified = typeof body === 'string' && body.includes('data-success');
+
+      if (!verified && attempt < maxAttempts) {
+        this.submitNewestCode(email, attempt + 1);
+      }
+    });
   }
 
   executeWithInvalidCode(credentials: LoginCredentials, staticFixtures: CustomerMfaAuthStaticFixtures): void {

--- a/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
@@ -9,43 +9,20 @@ export class CustomerMfaLoginScenario {
   @inject(MultiFactorAuthPage) private mfaPage: MultiFactorAuthPage;
 
   execute(credentials: LoginCredentials): void {
-    cy.intercept('POST', '**/multi-factor-auth/send-user-code').as('mfaCodeSubmit');
-
     this.loginPage.visit();
     this.loginPage.login(credentials);
 
     this.mfaPage.waitForVerificationPopup();
 
-    this.submitNewestCode(credentials.email);
+    cy.intercept('POST', '**/multi-factor-auth/send-customer-code').as('mfaCodeValidation');
 
-    // After a successful verification the popup reloads the page; wait for the redirect off the
-    // login page to land so the next visit() does not race the just-established session.
-    cy.url({ timeout: 20000 }).should('not.include', '/login');
-  }
-
-  /**
-   * While it initialises, the login MFA popup requests a fresh verification code and can do so more
-   * than once. The backend keeps every code but only accepts the most recently generated one, so the
-   * first code read from the DB may already be stale by the time it is submitted — which left the
-   * test stuck on /login. A rejected submit re-renders the validation form without issuing a new
-   * code, so re-reading the (now stable) newest code and submitting again succeeds. Bounded to stay
-   * within the backend attempt limit.
-   */
-  private submitNewestCode(email: string, attempt = 1): void {
-    const maxAttempts = 3;
-
-    cy.getMultiFactorAuthCode(email, 'email').then((code) => {
+    cy.getMultiFactorAuthCode(credentials.email, 'email').then((code) => {
       this.mfaPage.verifyCode(code);
     });
 
-    cy.wait('@mfaCodeSubmit').then((interception) => {
-      const body = interception.response?.body;
-      const verified = typeof body === 'string' && body.includes('data-success');
-
-      if (!verified && attempt < maxAttempts) {
-        this.submitNewestCode(email, attempt + 1);
-      }
-    });
+    // Wait for verification to succeed (session upgraded server-side) before the caller navigates,
+    // otherwise the test races the post-MFA login and lands back on the login page.
+    cy.wait('@mfaCodeValidation').its('response.body').should('include', 'data-success');
   }
 
   executeWithInvalidCode(credentials: LoginCredentials, staticFixtures: CustomerMfaAuthStaticFixtures): void {

--- a/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
@@ -14,11 +14,11 @@ export class CustomerMfaLoginScenario {
 
     this.mfaPage.waitForVerificationPopup();
 
-    console.log('customer');
-
     cy.getMultiFactorAuthCode(credentials.email, 'email').then((code) => {
       this.mfaPage.verifyCode(code);
     });
+
+    cy.url({ timeout: 20000 }).should('not.include', '/login');
   }
 
   executeWithInvalidCode(credentials: LoginCredentials, staticFixtures: CustomerMfaAuthStaticFixtures): void {

--- a/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
+++ b/cypress/support/scenarios/yves/customer-mfa-login-scenario.ts
@@ -18,6 +18,10 @@ export class CustomerMfaLoginScenario {
       this.mfaPage.verifyCode(code);
     });
 
+    // verifyCode() submits the verification popup via fetch, so Cypress does not wait for a page
+    // load and the in-flight POST may not have established the MFA-passed session yet. Block until
+    // the redirect off the login page lands, otherwise the next visit() races that request and the
+    // customer guard bounces it back to /login.
     cy.url({ timeout: 20000 }).should('not.include', '/login');
   }
 


### PR DESCRIPTION
The success path of the agent/customer MFA login scenarios clicked the verification submit button and returned immediately. The verify popup is a JS web component (submits via fetch, not a page load), so Cypress did not wait for the request. The next step (visit /agent/overview) then raced the in-flight verify POST: the MFA-passed session flag was not set yet, the agent guard redirected to /agent/login, and assertPageLocation timed out at /agent/login on the slower CI shards.

Mirror the activation scenario (which waits for the success message) by asserting the challenge cleared before the scenario returns. Also drop the stray console.log in the customer scenario.

## PR Description

Add a meaningful description here that will let us know what you want to fix with this PR or what functionality you want to add.

## Steps before you submit a PR

- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
  `I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/cypress-tests/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist

- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
