### PR TITLE
CC-39347:  the "Set up as recurring order" JavaScript fires on the summary page

### DIFF
--- a/cypress/e2e/yves/checkout/basic-checkout.cy.ts
+++ b/cypress/e2e/yves/checkout/basic-checkout.cy.ts
@@ -28,7 +28,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     skipB2BIt('guest customer should checkout to multi shipment address', (): void => {
@@ -40,7 +40,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to single shipment (with customer shipping address)', (): void => {
@@ -61,7 +61,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED') ? true : false,
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to single shipment (with new shipping address)', (): void => {
@@ -81,7 +81,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED') ? true : false,
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
@@ -102,7 +102,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to multi shipment address (with new shipping address)', (): void => {
@@ -122,7 +122,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     function getPaymentMethodBasedOnEnv(): string {

--- a/cypress/support/scenarios/yves/checkout-scenario.ts
+++ b/cypress/support/scenarios/yves/checkout-scenario.ts
@@ -20,6 +20,9 @@ export class CheckoutScenario {
   @inject(CheckoutSummaryPage) private checkoutSummaryPage: CheckoutSummaryPage;
 
   execute = (params?: ExecuteParams): void => {
+    // Stub recurring-order/clear: its AJAX response replaces summary form HTML,
+    // unchecking T&C and disabling the submit button before placeOrder() can run.
+    cy.intercept('POST', '**/recurring-order/clear', { statusCode: 200, body: '' });
     this.cartPage.visit();
     this.cartPage.startCheckout();
     if (params?.isGuest) {
@@ -34,6 +37,9 @@ export class CheckoutScenario {
 
     if (!params?.shouldSkipPlaceOrder) {
       this.checkoutSummaryPage.placeOrder();
+      // Wait for redirect away from summary — B2B order processing can be slow,
+      // and CLI commands below must not run before the success page is reached.
+      cy.url({ timeout: 15000 }).should('not.include', '/checkout/summary');
     }
 
     if (params?.shouldTriggerOmsInCli) {


### PR DESCRIPTION
... does an AJAX reload that replaces the form HTML, and the fresh render has T&C unchecked and submit button disabled. When placeOrder() then submits, the form is submitted without the T&C flag →  server rejects it → redirects back to summary.

Ticket: https://spryker.atlassian.net/browse/CC-39347

B2B-MP:

<img width="846" height="822" alt="image" src="https://github.com/user-attachments/assets/76a7ac5c-7e47-458e-a97c-af77817a29e8" />


[Suite](https://github.com/spryker/suite/actions/runs/28248529906/job/83694890940):
<img width="889" height="888" alt="image" src="https://github.com/user-attachments/assets/fdc08098-547e-41e2-babf-dc73dc1d6978" />
