### PR TITLE
CC-39426 Re-enable customer checkout address-step tests on suite

### DIFF
--- a/cypress/e2e/yves/checkout/basic-checkout.cy.ts
+++ b/cypress/e2e/yves/checkout/basic-checkout.cy.ts
@@ -43,7 +43,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to single shipment (with customer shipping address)', (): void => {
+    it('customer should checkout to single shipment (with customer shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -64,7 +64,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to single shipment (with new shipping address)', (): void => {
+    it('customer should checkout to single shipment (with new shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -84,7 +84,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
+    it('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -105,7 +105,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to multi shipment address (with new shipping address)', (): void => {
+    it('customer should checkout to multi shipment address (with new shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -143,10 +143,6 @@ describe(
 
     function skipB2BIt(description: string, testFn: () => void): void {
       (['b2b', 'b2b-mp'].includes(Cypress.env('repositoryId')) ? it.skip : it)(description, testFn);
-    }
-
-    function skipSuiteIt(description: string, testFn: () => void): void {
-      (Cypress.env('repositoryId') === 'suite' ? it.skip : it)(description, testFn);
     }
   }
 );


### PR DESCRIPTION
## Summary
Re-enables the four logged-in-customer checkout address-step tests in `basic-checkout.cy.ts` that were temporarily `it.skip`-gated on the suite repo in #333 (CC-39426).

The underlying defect — a stale Propel-pooled customer entity returning an empty addresses relation at the checkout address step (the shipping-address block is gated on `id_customer_address`, so it vanishes and the spec fails) — is fixed suite-side by forcing a fresh read in `Customer::attachAddresses()`.

## ⚠️ Merge order — hard dependency
**Do not merge until the suite-side fix is on suite `master`.** Until then, suite master and other PRs install `cypress-tests:dev-master` without the fix, and these four tests would fail again everywhere. The fix currently rides on suite PR spryker/suite#769 — merge this only after that lands on master.

## Validation
On a focused compatibility-CI run with the suite fix + these tests re-enabled, `basic-checkout.cy.ts` was **6/6 green** (all four customer single/multi-shipment, customer/new-address variants), and the AclEntity functional suite stayed green.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md