### PR TITLE
CC-39347: Re-enable suite checkout tests fixed in #331

### DIFF
--- a/cypress/e2e/yves/checkout/basic-checkout.cy.ts
+++ b/cypress/e2e/yves/checkout/basic-checkout.cy.ts
@@ -43,7 +43,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to single shipment (with customer shipping address)', (): void => {
+    it('customer should checkout to single shipment (with customer shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -64,7 +64,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to single shipment (with new shipping address)', (): void => {
+    it('customer should checkout to single shipment (with new shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -84,7 +84,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
+    it('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -105,7 +105,7 @@ describe(
       cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
-    skipSuiteIt('customer should checkout to multi shipment address (with new shipping address)', (): void => {
+    it('customer should checkout to multi shipment address (with new shipping address)', (): void => {
       loginCustomerScenario.execute({
         email: dynamicFixtures.customer.email,
         password: staticFixtures.defaultPassword,
@@ -143,10 +143,6 @@ describe(
 
     function skipB2BIt(description: string, testFn: () => void): void {
       (['b2b', 'b2b-mp'].includes(Cypress.env('repositoryId')) ? it.skip : it)(description, testFn);
-    }
-
-    function skipSuiteIt(description: string, testFn: () => void): void {
-      (Cypress.env('repositoryId') === 'suite' ? it.skip : it)(description, testFn);
     }
   }
 );


### PR DESCRIPTION
## Summary

- Remove `skipSuiteIt` wrapper from 4 logged-in customer checkout tests in `basic-checkout.cy.ts`
- Drop the now-unused `skipSuiteIt` helper function

The tests were temporarily skipped in #333 due to a flaky failure on suite. The root cause (recurring order widget JavaScript firing an AJAX reload on the summary page, which unchecked T&C and disabled submit) was fixed in #331. Tests are safe to run on suite again.

## Test plan

- [ ] Verify the 4 re-enabled checkout tests pass on suite in CI