### PR TITLE
CC-39479 Wait for PLP badge propagation in product attribute visibility test

### DIFF
--- a/cypress/e2e/yves/product-attribute-visibility/product-attribute-visibility.cy.ts
+++ b/cypress/e2e/yves/product-attribute-visibility/product-attribute-visibility.cy.ts
@@ -38,8 +38,6 @@ describe(
     });
 
     it('Should display attribute badges', (): void => {
-      // Wait for the badge to actually appear before asserting: the PLP reads from
-      // ES/Redis storage that lags the async publish worker triggered above.
       attributeVisibilityPage.visitSearchAndWaitForBadgeVisible(
         dynamicFixtures.product.abstract_sku,
         staticFixtures.attributeValue
@@ -65,8 +63,6 @@ describe(
       editPage.updateAttributeVisibility(staticFixtures.attributeKey, ['PDP']);
       cy.runQueueWorker();
 
-      // Wait for the badge to actually disappear before asserting: the stale badge
-      // lingers on the PLP until the publish worker's removal propagates to storage.
       attributeVisibilityPage.visitSearchAndWaitForBadgeNotVisible(
         dynamicFixtures.product.abstract_sku,
         staticFixtures.attributeValue
@@ -95,7 +91,6 @@ describe(
       attributeVisibilityPage.navigateToProductDetailPage(dynamicFixtures.product.abstract_sku);
       attributeVisibilityPage.assertPdpAttributeNotVisible(staticFixtures.attributeValue);
 
-      // Wait for the badge to actually disappear before asserting (async publish lag).
       attributeVisibilityPage.visitSearchAndWaitForBadgeNotVisible(
         dynamicFixtures.product.abstract_sku,
         staticFixtures.attributeValue

--- a/cypress/e2e/yves/product-attribute-visibility/product-attribute-visibility.cy.ts
+++ b/cypress/e2e/yves/product-attribute-visibility/product-attribute-visibility.cy.ts
@@ -38,7 +38,12 @@ describe(
     });
 
     it('Should display attribute badges', (): void => {
-      attributeVisibilityPage.visitSearchAndWaitForProduct(dynamicFixtures.product.abstract_sku);
+      // Wait for the badge to actually appear before asserting: the PLP reads from
+      // ES/Redis storage that lags the async publish worker triggered above.
+      attributeVisibilityPage.visitSearchAndWaitForBadgeVisible(
+        dynamicFixtures.product.abstract_sku,
+        staticFixtures.attributeValue
+      );
       attributeVisibilityPage.assertPlpAttributeBadgeVisible(staticFixtures.attributeValue);
 
       attributeVisibilityPage.navigateToProductDetailPage(dynamicFixtures.product.abstract_sku);
@@ -60,7 +65,12 @@ describe(
       editPage.updateAttributeVisibility(staticFixtures.attributeKey, ['PDP']);
       cy.runQueueWorker();
 
-      attributeVisibilityPage.visitSearchAndWaitForProduct(dynamicFixtures.product.abstract_sku);
+      // Wait for the badge to actually disappear before asserting: the stale badge
+      // lingers on the PLP until the publish worker's removal propagates to storage.
+      attributeVisibilityPage.visitSearchAndWaitForBadgeNotVisible(
+        dynamicFixtures.product.abstract_sku,
+        staticFixtures.attributeValue
+      );
       attributeVisibilityPage.assertPlpAttributeBadgeNotVisible(staticFixtures.attributeValue);
 
       attributeVisibilityPage.navigateToProductDetailPage(dynamicFixtures.product.abstract_sku);
@@ -85,7 +95,11 @@ describe(
       attributeVisibilityPage.navigateToProductDetailPage(dynamicFixtures.product.abstract_sku);
       attributeVisibilityPage.assertPdpAttributeNotVisible(staticFixtures.attributeValue);
 
-      attributeVisibilityPage.visitSearchAndWaitForProduct(dynamicFixtures.product.abstract_sku);
+      // Wait for the badge to actually disappear before asserting (async publish lag).
+      attributeVisibilityPage.visitSearchAndWaitForBadgeNotVisible(
+        dynamicFixtures.product.abstract_sku,
+        staticFixtures.attributeValue
+      );
       attributeVisibilityPage.assertPlpAttributeBadgeNotVisible(staticFixtures.attributeValue);
 
       customerLoginScenario.execute({

--- a/cypress/support/pages/yves/product-attribute-visibility/product-attribute-visibility-page.ts
+++ b/cypress/support/pages/yves/product-attribute-visibility/product-attribute-visibility-page.ts
@@ -14,6 +14,40 @@ export class ProductAttributeVisibilityPage extends YvesPage {
     cy.reloadUntilFound(`/search?q=${query}`, this.repository.getProductItemSelector(), 'body', 3, 1000);
   };
 
+  // Flaky fix: the product tile is always indexed from fixtures, so waiting for the
+  // tile returns before the just-published visibility change has propagated to
+  // ES/Redis. Reload the PLP until the badge state itself matches, so the following
+  // assertion no longer races the async publish worker.
+  visitSearchAndWaitForBadgeVisible = (query: string, attributeValue: string): void => {
+    this.reloadSearchUntilBadgeState(query, attributeValue, true);
+  };
+
+  visitSearchAndWaitForBadgeNotVisible = (query: string, attributeValue: string): void => {
+    this.reloadSearchUntilBadgeState(query, attributeValue, false);
+  };
+
+  private reloadSearchUntilBadgeState = (
+    query: string,
+    attributeValue: string,
+    shouldBeVisible: boolean,
+    retries = 8,
+    retryWait = 1000
+  ): void => {
+    cy.visit(`/search?q=${query}`);
+    cy.get('body').then(($body) => {
+      const item = $body.find(this.repository.getProductItemSelector()).first();
+      const badgeVisible =
+        item.find(`${this.repository.getAttributeBadgeSelector()}:contains("${attributeValue}")`).length > 0;
+
+      if (badgeVisible === shouldBeVisible || retries === 0) {
+        return;
+      }
+
+      cy.wait(retryWait);
+      this.reloadSearchUntilBadgeState(query, attributeValue, shouldBeVisible, retries - 1, retryWait);
+    });
+  };
+
   navigateToProductDetailPage = (abstractSku: string): void => {
     this.visitSearchAndWaitForProduct(abstractSku);
 

--- a/cypress/support/pages/yves/product-attribute-visibility/product-attribute-visibility-page.ts
+++ b/cypress/support/pages/yves/product-attribute-visibility/product-attribute-visibility-page.ts
@@ -14,18 +14,28 @@ export class ProductAttributeVisibilityPage extends YvesPage {
     cy.reloadUntilFound(`/search?q=${query}`, this.repository.getProductItemSelector(), 'body', 3, 1000);
   };
 
-  // Flaky fix: the product tile is always indexed from fixtures, so waiting for the
-  // tile returns before the just-published visibility change has propagated to
-  // ES/Redis. Reload the PLP until the badge state itself matches, so the following
-  // assertion no longer races the async publish worker.
+  /**
+   * Reloads the PLP until the attribute badge is visible before returning.
+   * The product tile is always indexed from fixtures, so waiting on the tile returns
+   * before a just-published visibility change has propagated to ES/Redis — this keeps
+   * the following assertion from racing the async publish worker.
+   */
   visitSearchAndWaitForBadgeVisible = (query: string, attributeValue: string): void => {
     this.reloadSearchUntilBadgeState(query, attributeValue, true);
   };
 
+  /**
+   * Reloads the PLP until the attribute badge is no longer visible before returning.
+   * The stale badge lingers on the PLP until the publish worker's removal reaches storage.
+   */
   visitSearchAndWaitForBadgeNotVisible = (query: string, attributeValue: string): void => {
     this.reloadSearchUntilBadgeState(query, attributeValue, false);
   };
 
+  /**
+   * Reloads `/search?q=<query>` until the first tile's attribute badge matches
+   * `shouldBeVisible`, or `retries` is exhausted.
+   */
   private reloadSearchUntilBadgeState = (
     query: string,
     attributeValue: string,


### PR DESCRIPTION
Fixes the flaky `product-attribute-visibility.cy.ts` storefront spec. The PLP reads attribute badges from ES/Redis storage that lags the async publish worker, but `visitSearchAndWaitForProduct` only waited for the always-present product tile — so the badge assertions raced stale state. Adds `visitSearchAndWaitForBadgeVisible`/`NotVisible` helpers that reload the PLP until the badge state itself matches before asserting.

Ticket: https://spryker.atlassian.net/browse/CC-39479
Paired suite PR: spryker/suite#842 — its composer.json/lock point at this branch until this merges, then flips back to dev-master.

Test plan: focused Cypress CI on the paired suite branch (product-attribute-visibility spec across the UI shards).