### PR TITLE
CC-38848 Seed both product attachments in-test to stop flaky length assertion

### DIFF
--- a/cypress/e2e/yves/product/product-attachment-storefront.cy.ts
+++ b/cypress/e2e/yves/product/product-attachment-storefront.cy.ts
@@ -146,11 +146,20 @@ describe(
       productManagementEditPage.openMediaTab();
 
       // Arrange
+      // Seed both attachments here in one publish instead of leaning on the EN
+      // attachment left behind by the previous test: that cross-test coupling made
+      // length==2 race the sibling test's async publish (found 1, expected 2).
       productManagementEditPage.deleteAttachmentsForLocale(staticFixtures.defaultLocaleName);
+      clearAllLocalizedAttachments(dynamicFixtures.localeEN.locale_name);
       productManagementEditPage.addAttachment({
         ...staticFixtures.attachments.temporaryGuide,
         index: 0,
         locale: staticFixtures.defaultLocaleName,
+      });
+      productManagementEditPage.addAttachment({
+        ...staticFixtures.attachments.enGuide,
+        index: 0,
+        locale: dynamicFixtures.localeEN.locale_name,
       });
       productManagementEditPage.save();
 
@@ -159,7 +168,7 @@ describe(
       cy.runQueueWorker();
 
       visitProductDetailPage();
-      // en_US attachment from previous test + default "Temporary Guide"
+      // EN-locale "EN Guide" + default "Temporary Guide", both seeded above
       productPage.getAttachmentItems().should('have.length', 2);
 
       // Act


### PR DESCRIPTION
Fixes the flaky `product-attachment-storefront.cy.ts` "attachments removed in backoffice" case.

The `have.length', 2` assertion depended on an en_US attachment left behind by the previous sibling test plus its own default-locale one — a cross-test data dependency that raced the sibling's async publish. This seeds both attachments in-test in a single publish, removing the coupling.

Jira: https://spryker.atlassian.net/browse/CC-38848

**Test plan:** focused CI (framework=cypress) green — all 5 Cypress UI shards pass: https://github.com/spryker/suite/actions/runs/28567796934