### PR TITLE
CC-39514 Fix flaky SSP file-management asset-attach Cypress test

### DIFF
--- a/cypress/e2e/backoffice/ssp-file-management/ssp-file-management.cy.ts
+++ b/cypress/e2e/backoffice/ssp-file-management/ssp-file-management.cy.ts
@@ -126,6 +126,9 @@ describe(
       fileManagerAttachmentListPage.visit();
       fileManagerAttachmentListPage.clickAttachButton();
 
+      // Parity with the sibling attach blocks: activate the Asset tab first so the
+      // nav-tabs settle and the unattached table is rendered before we search it.
+      fileManagerAttachmentAttachPage.selectAttachmentScope('asset');
       fileManagerAttachmentAttachPage.selectAvailableItems('asset', [dynamicFixtures.sspAsset.name]);
       fileManagerAttachmentAttachPage.submitForm();
       fileManagerAttachmentAttachPage.verifySuccessMessage();

--- a/cypress/support/pages/backoffice/ssp-file-management/attach/ssp-file-management-attach-page.ts
+++ b/cypress/support/pages/backoffice/ssp-file-management/attach/ssp-file-management-attach-page.ts
@@ -90,8 +90,16 @@ export class SspFileManagementAttachPage extends BackofficePage {
     searchTerms.forEach((searchTerm) => {
       cy.get(searchSelector).clear();
       cy.get(searchSelector).type(searchTerm);
+      // Flaked: DataTables filters via a server-side AJAX. Checking the first row
+      // before its `_processing` overlay settles ticks a stale/empty row, submits
+      // an empty attachment, and (on suite's single seeded asset) removes it from
+      // the unattached list so non-DB-resetting retries find nothing and the
+      // success toast never fires. Wait for the filter to settle and require the
+      // top row to actually match the search term before checking it.
+      cy.get(`${tableSelector}_processing`, { timeout: 10000 }).should('not.be.visible');
       cy.get(`${tableSelector} tbody tr`)
         .first()
+        .should('contain', searchTerm)
         .find(this.repository.getTableRowCheckboxSelector(), { timeout: 10000 })
         .check({ force: true });
     });


### PR DESCRIPTION
Stabilises the asset-attach block in `ssp-file-management.cy.ts`, which failed all 3 attempts while its siblings passed. Detail in the Jira ticket.

- Activate the Asset tab before searching the unattached table (parity with the sibling attach blocks).
- Wait for the DataTables server-side filter to settle and require the top row to match the search term before checking it — stops an empty/stale row from being submitted and consuming the single seeded asset.

Consumed by suite PR spryker/suite#850.

Jira: [CC-39514](https://spryker.atlassian.net/browse/CC-39514)

## Test plan
- Focused Cypress run of `ssp-file-management.cy.ts` green across repeated attempts.