### PR TITLE
CC-39568 Add local ESLint plugin enforcing cypress test conventions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "spryker-cypress"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
@@ -15,6 +15,26 @@
   },
   "rules": {
     "@typescript-eslint/no-inferrable-types": "error",
-    "@typescript-eslint/explicit-function-return-type": "error"
-  }
+    "@typescript-eslint/explicit-function-return-type": "error",
+    // Local conventions plugin: plugins/eslint-plugin-spryker-cypress (linked via file: devDependency).
+    // Rules with pre-existing violations are registered as "warn" so lint stays green while
+    // new code surfaces the issue; tighten to "error" once the backlog is cleaned up.
+    // ~165 pre-existing selector calls in specs -> warn.
+    "spryker-cypress/no-cy-get-outside-repository": "warn",
+    // 7 pre-existing fixed waits (their inline disables target cypress/no-unnecessary-waiting only) -> warn.
+    "spryker-cypress/no-numeric-wait": "warn",
+    // Convention already followed everywhere (tags on the top-level describe) -> error.
+    "spryker-cypress/require-describe-tags": "error",
+    // Intentionally a warning: ~449 existing assertions live in page objects today.
+    "spryker-cypress/no-assertions-in-page-objects": "warn"
+  },
+  "overrides": [
+    {
+      // Typed fixtures and selector repositories must never fall back to `any`.
+      "files": ["cypress/fixtures/**/*.ts", "cypress/**/repositories/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "error"
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dotenv": "^16.4.5",
         "eslint": "^8.57.0",
         "eslint-plugin-cypress": "^2.15.2",
+        "eslint-plugin-spryker-cypress": "file:plugins/eslint-plugin-spryker-cypress",
         "inversify": "^6.0.2",
         "prettier": "^3.4.1",
         "reflect-metadata": "^0.2.2",
@@ -2047,6 +2048,10 @@
       "peerDependencies": {
         "eslint": ">= 3.2.1"
       }
+    },
+    "node_modules/eslint-plugin-spryker-cypress": {
+      "resolved": "plugins/eslint-plugin-spryker-cypress",
+      "link": true
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
@@ -4361,6 +4366,13 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "plugins/eslint-plugin-spryker-cypress": {
+      "version": "1.0.0",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "eslint-plugin-cypress": "^2.15.2",
+    "eslint-plugin-spryker-cypress": "file:plugins/eslint-plugin-spryker-cypress",
     "inversify": "^6.0.2",
     "prettier": "^3.4.1",
     "reflect-metadata": "^0.2.2",

--- a/plugins/eslint-plugin-spryker-cypress/index.js
+++ b/plugins/eslint-plugin-spryker-cypress/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'no-cy-get-outside-repository': require('./rules/no-cy-get-outside-repository'),
+    'no-numeric-wait': require('./rules/no-numeric-wait'),
+    'require-describe-tags': require('./rules/require-describe-tags'),
+    'no-assertions-in-page-objects': require('./rules/no-assertions-in-page-objects'),
+  },
+};

--- a/plugins/eslint-plugin-spryker-cypress/package.json
+++ b/plugins/eslint-plugin-spryker-cypress/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "eslint-plugin-spryker-cypress",
+  "version": "1.0.0",
+  "description": "Local ESLint plugin enforcing Spryker Cypress test conventions.",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "test": "node tests/run.js"
+  },
+  "peerDependencies": {
+    "eslint": ">=8"
+  }
+}

--- a/plugins/eslint-plugin-spryker-cypress/rules/no-assertions-in-page-objects.js
+++ b/plugins/eslint-plugin-spryker-cypress/rules/no-assertions-in-page-objects.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * Page objects (files under a pages/ directory) should expose state and
+ * actions; asserting belongs to the spec. Flags .should(...) chains and
+ * expect(...) calls inside page-object files.
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Discourage .should()/expect() assertions inside page objects; assert in the spec instead.',
+    },
+    schema: [],
+    messages: {
+      assertion: 'Avoid {{kind}} assertions inside page objects; return the element or value and assert in the spec.',
+    },
+  },
+
+  create(context) {
+    const filename = context.getFilename().replace(/\\/g, '/');
+
+    if (!/\/pages\//.test(filename)) {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+
+        if (callee.type === 'Identifier' && callee.name === 'expect') {
+          context.report({ node, messageId: 'assertion', data: { kind: 'expect()' } });
+
+          return;
+        }
+
+        if (
+          callee.type === 'MemberExpression' &&
+          !callee.computed &&
+          callee.property.type === 'Identifier' &&
+          callee.property.name === 'should'
+        ) {
+          context.report({ node, messageId: 'assertion', data: { kind: '.should()' } });
+        }
+      },
+    };
+  },
+};

--- a/plugins/eslint-plugin-spryker-cypress/rules/no-cy-get-outside-repository.js
+++ b/plugins/eslint-plugin-spryker-cypress/rules/no-cy-get-outside-repository.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * Selectors belong to repository classes (cypress/support/pages/**\/repositories/)
+ * so that specs and page objects stay selector-free. This rule forbids direct
+ * cy.get() / cy.contains() calls in any file that is not located under a
+ * `repositories/` or `support/` directory.
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Forbid cy.get()/cy.contains() outside repository and support files; selectors belong to repository classes.',
+    },
+    schema: [],
+    messages: {
+      forbidden:
+        'cy.{{method}}() is not allowed here. Move the selector into a repository class (repositories/ directory) and access it through the page object.',
+    },
+  },
+
+  create(context) {
+    const filename = context.getFilename().replace(/\\/g, '/');
+
+    if (/\/(repositories|support)\//.test(filename)) {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+
+        if (
+          callee.type === 'MemberExpression' &&
+          !callee.computed &&
+          callee.object.type === 'Identifier' &&
+          callee.object.name === 'cy' &&
+          callee.property.type === 'Identifier' &&
+          (callee.property.name === 'get' || callee.property.name === 'contains')
+        ) {
+          context.report({
+            node,
+            messageId: 'forbidden',
+            data: { method: callee.property.name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/plugins/eslint-plugin-spryker-cypress/rules/no-numeric-wait.js
+++ b/plugins/eslint-plugin-spryker-cypress/rules/no-numeric-wait.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * Forbids fixed-duration waits: cy.wait(5000). Waiting for a fixed amount of
+ * time makes tests slow and flaky. Wait on an intercepted alias instead:
+ * cy.wait('@request').
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: "Forbid cy.wait(<number>); wait on an intercepted alias (cy.wait('@alias')) instead.",
+    },
+    schema: [],
+    messages: {
+      numericWait: "Do not wait a fixed {{value}} ms; wait on an intercepted alias instead, e.g. cy.wait('@request').",
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.computed ||
+          callee.object.type !== 'Identifier' ||
+          callee.object.name !== 'cy' ||
+          callee.property.type !== 'Identifier' ||
+          callee.property.name !== 'wait'
+        ) {
+          return;
+        }
+
+        const firstArgument = node.arguments[0];
+
+        if (firstArgument && firstArgument.type === 'Literal' && typeof firstArgument.value === 'number') {
+          context.report({
+            node,
+            messageId: 'numericWait',
+            data: { value: String(firstArgument.value) },
+          });
+        }
+      },
+    };
+  },
+};

--- a/plugins/eslint-plugin-spryker-cypress/rules/require-describe-tags.js
+++ b/plugins/eslint-plugin-spryker-cypress/rules/require-describe-tags.js
@@ -1,0 +1,102 @@
+'use strict';
+
+/**
+ * Every top-level describe() block must declare @cypress/grep tags via a
+ * configuration object as the second argument:
+ *
+ *   describe('name', { tags: ['@smoke', 'spryker-core'] }, () => { ... });
+ *
+ * Tags drive suite selection (sharding, smoke runs), so untagged suites are
+ * invisible to the tag-filtered CI pipelines. Nested describe() blocks inherit
+ * the tags of their parent suite and are therefore exempt — this matches the
+ * existing specs (e.g. merchant-registration.cy.ts), which tag only the
+ * outermost describe.
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: "Require every top-level describe() to declare tags: describe('...', { tags: [...] }, () => ...).",
+    },
+    schema: [],
+    messages: {
+      missingTags:
+        "Top-level describe() must declare grep tags via a configuration object as second argument: describe('...', { tags: [...] }, () => ...).",
+    },
+  },
+
+  create(context) {
+    let describeDepth = 0;
+
+    const isDescribeCallee = (callee) => {
+      if (callee.type === 'Identifier' && callee.name === 'describe') {
+        return true;
+      }
+
+      return (
+        callee.type === 'MemberExpression' &&
+        !callee.computed &&
+        callee.object.type === 'Identifier' &&
+        callee.object.name === 'describe' &&
+        callee.property.type === 'Identifier' &&
+        (callee.property.name === 'only' || callee.property.name === 'skip')
+      );
+    };
+
+    const hasTagsProperty = (objectExpression) =>
+      objectExpression.properties.some(
+        (property) =>
+          property.type === 'Property' &&
+          !property.computed &&
+          ((property.key.type === 'Identifier' && property.key.name === 'tags') ||
+            (property.key.type === 'Literal' && property.key.value === 'tags'))
+      );
+
+    const containsSpread = (objectExpression) =>
+      objectExpression.properties.some((property) => property.type === 'SpreadElement');
+
+    const checkTopLevelDescribe = (node) => {
+      const configArgument = node.arguments[1];
+
+      if (!configArgument) {
+        context.report({ node, messageId: 'missingTags' });
+
+        return;
+      }
+
+      if (configArgument.type === 'ObjectExpression') {
+        if (!hasTagsProperty(configArgument) && !containsSpread(configArgument)) {
+          context.report({ node, messageId: 'missingTags' });
+        }
+
+        return;
+      }
+
+      // describe('name', () => {}) — second argument is the suite callback, no config object at all.
+      if (configArgument.type === 'ArrowFunctionExpression' || configArgument.type === 'FunctionExpression') {
+        context.report({ node, messageId: 'missingTags' });
+      }
+
+      // Anything else (identifier, call, …) cannot be verified statically; do not report.
+    };
+
+    return {
+      CallExpression(node) {
+        if (!isDescribeCallee(node.callee)) {
+          return;
+        }
+
+        if (describeDepth === 0) {
+          checkTopLevelDescribe(node);
+        }
+
+        describeDepth++;
+      },
+      'CallExpression:exit'(node) {
+        if (isDescribeCallee(node.callee)) {
+          describeDepth--;
+        }
+      },
+    };
+  },
+};

--- a/plugins/eslint-plugin-spryker-cypress/tests/run.js
+++ b/plugins/eslint-plugin-spryker-cypress/tests/run.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * Rule tests for eslint-plugin-spryker-cypress.
+ *
+ * Run with: node plugins/eslint-plugin-spryker-cypress/tests/run.js
+ * RuleTester throws on the first failing assertion, so a zero exit code means
+ * every test passed. No test-runner dependency needed.
+ */
+const { RuleTester } = require('eslint');
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+});
+
+const specFile = 'cypress/e2e/yves/login/login.cy.ts';
+const repositoryFile = 'cypress/support/pages/yves/login/repositories/suite-login-repository.ts';
+const supportFile = 'cypress/support/commands.ts';
+const pageFile = 'cypress/support/pages/yves/login/login-page.ts';
+
+ruleTester.run('no-cy-get-outside-repository', require('../rules/no-cy-get-outside-repository'), {
+  valid: [
+    { code: "cy.get('#loginForm_email');", filename: repositoryFile },
+    { code: "cy.contains('Login');", filename: repositoryFile },
+    { code: "cy.get('[data-qa=submit]');", filename: supportFile },
+    { code: "cy.visit('/login');", filename: specFile },
+    { code: "cy.intercept('POST', '/login');", filename: specFile },
+    { code: 'repository.getLoginForm().submit();', filename: specFile },
+    // computed access is not flagged
+    { code: "cy['get']('#id');", filename: specFile },
+    // in this repo page objects live under cypress/support/, so the support allowance covers them
+    { code: "cy.get('.menu');", filename: pageFile },
+  ],
+  invalid: [
+    {
+      code: "cy.get('#loginForm_email').type('a@b.c');",
+      filename: specFile,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "cy.contains('Add to cart').click();",
+      filename: specFile,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: "cy.get('.menu');",
+      filename: 'cypress.config.ts',
+      errors: [{ messageId: 'forbidden' }],
+    },
+  ],
+});
+
+ruleTester.run('no-numeric-wait', require('../rules/no-numeric-wait'), {
+  valid: [
+    { code: "cy.wait('@loginRequest');", filename: specFile },
+    { code: "cy.wait(['@a', '@b']);", filename: specFile },
+    { code: "cy.wait('@request', { timeout: 10000 });", filename: specFile },
+    // non-cy waits are out of scope
+    { code: 'queue.wait(500);', filename: specFile },
+  ],
+  invalid: [
+    { code: 'cy.wait(5000);', filename: specFile, errors: [{ messageId: 'numericWait' }] },
+    { code: 'cy.wait(0);', filename: specFile, errors: [{ messageId: 'numericWait' }] },
+    { code: 'cy.wait(15000); // sync', filename: supportFile, errors: [{ messageId: 'numericWait' }] },
+  ],
+});
+
+ruleTester.run('require-describe-tags', require('../rules/require-describe-tags'), {
+  valid: [
+    {
+      code: "describe('health check', { tags: ['@smoke', '@api'] }, () => {});",
+      filename: specFile,
+    },
+    {
+      code: "describe.skip('wip', { tags: ['@yves'] }, () => {});",
+      filename: specFile,
+    },
+    {
+      code: "describe('quoted key', { 'tags': ['@mp'] }, () => {});",
+      filename: specFile,
+    },
+    // config held in a variable cannot be verified statically — not reported
+    {
+      code: "describe('dynamic', suiteConfig, () => {});",
+      filename: specFile,
+    },
+    // spread may carry tags — not reported
+    {
+      code: "describe('spread', { ...baseConfig }, () => {});",
+      filename: specFile,
+    },
+    // other mocha callables are out of scope
+    { code: "it('works', () => {});", filename: specFile },
+    // nested describes inherit the parent tags and need none of their own
+    {
+      code: "describe('outer', { tags: ['@yves'] }, () => { describe('inner', () => { it('works', () => {}); }); });",
+      filename: specFile,
+    },
+  ],
+  invalid: [
+    {
+      code: "describe('untagged', () => {});",
+      filename: specFile,
+      errors: [{ messageId: 'missingTags' }],
+    },
+    {
+      code: "describe('untagged');",
+      filename: specFile,
+      errors: [{ messageId: 'missingTags' }],
+    },
+    {
+      code: "describe('config without tags', { retries: 2 }, () => {});",
+      filename: specFile,
+      errors: [{ messageId: 'missingTags' }],
+    },
+    {
+      code: "describe.only('untagged', () => {});",
+      filename: specFile,
+      errors: [{ messageId: 'missingTags' }],
+    },
+    // sibling top-level describes are each checked (depth bookkeeping survives the first suite)
+    {
+      code: "describe('first', { tags: ['@yves'] }, () => {}); describe('second', () => {});",
+      filename: specFile,
+      errors: [{ messageId: 'missingTags' }],
+    },
+  ],
+});
+
+ruleTester.run('no-assertions-in-page-objects', require('../rules/no-assertions-in-page-objects'), {
+  valid: [
+    // assertions outside pages/ are fine
+    { code: "cy.get('.msg').should('be.visible');", filename: specFile },
+    { code: 'expect(total).to.equal(3);', filename: specFile },
+    { code: 'expect(total).to.equal(3);', filename: supportFile },
+    // non-assertion page-object code
+    { code: 'this.repository.getLoginForm().submit();', filename: pageFile },
+  ],
+  invalid: [
+    {
+      code: "this.repository.getMessage().should('be.visible');",
+      filename: pageFile,
+      errors: [{ messageId: 'assertion' }],
+    },
+    {
+      code: 'expect(rows.length).to.equal(1);',
+      filename: pageFile,
+      errors: [{ messageId: 'assertion' }],
+    },
+    {
+      code: "cy.get('.row').should('have.length', 2);",
+      filename: repositoryFile,
+      errors: [{ messageId: 'assertion' }],
+    },
+  ],
+});
+
+console.log('eslint-plugin-spryker-cypress: all rule tests passed.');


### PR DESCRIPTION
## Summary

Local ESLint plugin (plugins/eslint-plugin-spryker-cypress, wired as a file: devDependency) enforcing the cypress-e2e-test conventions: no cy.get/cy.contains outside repositories/support, no numeric cy.wait, tags required on top-level describe, no assertions in page objects, and scoped @typescript-eslint/no-explicit-any for fixtures/repositories. Pre-existing violations are registered as warnings (counts in .eslintrc comments); new violations surface going forward.

Jira: https://spryker.atlassian.net/browse/CC-39568

## Test plan

- node plugins/eslint-plugin-spryker-cypress/tests/run.js (34 RuleTester cases, green)
- npm run lint: exit 0 (621 warnings, 0 errors)
- npm run typecheck + prettier:check: green