### PR TITLE
CC-39568 Add AbstractPage.assertBodyContainsText helper

### DIFF
--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,7 +10,8 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
-  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+  assertBodyContainsText = (text: string, options?: Partial<Cypress.Timeoutable>): Cypress.Chainable =>
+    cy.get('body').contains(text, options);
 
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,5 +10,7 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
+  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }


### PR DESCRIPTION
## Summary
Adds `AbstractPage.assertBodyContainsText(text)`, wrapping `cy.get('body').contains(text)`. This is step 1 of clearing the `spryker-cypress/no-cy-get-outside-repository` backlog (165 violations across 41 spec files) introduced in #343 — see the "no-cy-get-outside-repository cleanup" plan referenced by that PR's context (CC-39568). Every spec that currently does `cy.contains(someFixtureValue)` for a generic "text is visible" check can now call this instead. Follow-up PRs will swap the call sites in (~90 of the 165 sites use this exact pattern).

No spec files are touched in this PR — single-file, zero behavior change to existing specs.

## Test plan
- [x] `npm run lint` — no new warnings/errors on `cypress/support/pages/abstract-page.ts` (repo-wide count unchanged at 621; `no-cy-get-outside-repository` unaffected since no call sites changed yet)
- [x] `npm run typecheck` — passes
- [ ] Spec verification — N/A, no spec files changed in this PR