### PR TITLE
CC-39568 Fix no-cy-get-outside-repository violations in mp specs

### DIFF
--- a/cypress/e2e/mp/data-import/merchant-combined-product.cy.ts
+++ b/cypress/e2e/mp/data-import/merchant-combined-product.cy.ts
@@ -76,7 +76,7 @@ describe(
       }
       catalogPage.visit();
       catalogPage.searchProductFromSuggestions({ query: abstractSku });
-      cy.contains(abstractSku);
+      catalogPage.assertBodyContainsText(abstractSku);
       productPage.getAddToCartButton().should('not.be.disabled');
 
       if (['suite', 'b2b-mp'].includes(Cypress.env('repositoryId'))) {

--- a/cypress/e2e/mp/marketplace-agent-assist/agent-authorization.cy.ts
+++ b/cypress/e2e/mp/marketplace-agent-assist/agent-authorization.cy.ts
@@ -64,7 +64,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(yvesAgentLoginPage.getFailedAuthenticationText());
+      yvesAgentLoginPage.assertBodyContainsText(yvesAgentLoginPage.getFailedAuthenticationText());
       yvesAgentLoginPage.assertPageLocation();
     });
 
@@ -75,7 +75,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(yvesAgentLoginPage.getFailedAuthenticationText());
+      yvesAgentLoginPage.assertBodyContainsText(yvesAgentLoginPage.getFailedAuthenticationText());
       yvesAgentLoginPage.assertPageLocation();
     });
 
@@ -86,7 +86,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(yvesLoginPage.getFailedAuthenticationText());
+      yvesLoginPage.assertBodyContainsText(yvesLoginPage.getFailedAuthenticationText());
       yvesLoginPage.assertPageLocation();
     });
 
@@ -97,7 +97,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(yvesLoginPage.getFailedAuthenticationText());
+      yvesLoginPage.assertBodyContainsText(yvesLoginPage.getFailedAuthenticationText());
       yvesLoginPage.assertPageLocation();
     });
 
@@ -108,7 +108,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(yvesLoginPage.getFailedAuthenticationText());
+      yvesLoginPage.assertBodyContainsText(yvesLoginPage.getFailedAuthenticationText());
       yvesLoginPage.assertPageLocation();
     });
   }

--- a/cypress/e2e/mp/marketplace-agent-assist/agent-dashboard.cy.ts
+++ b/cypress/e2e/mp/marketplace-agent-assist/agent-dashboard.cy.ts
@@ -45,12 +45,12 @@ describe(
       mpAgentDashboardPage.assertPageLocation();
       mpAgentDashboardPage.getDashboardSidebarSelector().contains('Merchant Users');
 
-      cy.contains('Merchant');
-      cy.contains('Merchant Approval');
-      cy.contains('First Name');
-      cy.contains('Last Name');
-      cy.contains('Email');
-      cy.contains('User Status');
+      mpAgentDashboardPage.assertBodyContainsText('Merchant');
+      mpAgentDashboardPage.assertBodyContainsText('Merchant Approval');
+      mpAgentDashboardPage.assertBodyContainsText('First Name');
+      mpAgentDashboardPage.assertBodyContainsText('Last Name');
+      mpAgentDashboardPage.assertBodyContainsText('Email');
+      mpAgentDashboardPage.assertBodyContainsText('User Status');
     });
 
     it('agent should be able to see active merchant user in a table', (): void => {

--- a/cypress/e2e/mp/marketplace-agent-assist/agent-login.cy.ts
+++ b/cypress/e2e/mp/marketplace-agent-assist/agent-login.cy.ts
@@ -47,7 +47,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(mpLoginPage.getFailedAuthenticationText());
+      mpLoginPage.assertBodyContainsText(mpLoginPage.getFailedAuthenticationText());
       mpLoginPage.assertPageLocation();
     });
 
@@ -58,7 +58,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(mpLoginPage.getFailedAuthenticationText());
+      mpLoginPage.assertBodyContainsText(mpLoginPage.getFailedAuthenticationText());
       mpLoginPage.assertPageLocation();
     });
 
@@ -69,7 +69,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains('Dashboard');
+      mpDashboardPage.assertBodyContainsText('Dashboard');
       mpDashboardPage.assertPageLocation();
     });
 
@@ -80,7 +80,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(mpLoginPage.getFailedAuthenticationText());
+      mpLoginPage.assertBodyContainsText(mpLoginPage.getFailedAuthenticationText());
       mpLoginPage.assertPageLocation();
     });
 
@@ -91,7 +91,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(mpLoginPage.getFailedAuthenticationText());
+      mpLoginPage.assertBodyContainsText(mpLoginPage.getFailedAuthenticationText());
       mpLoginPage.assertPageLocation();
     });
 
@@ -102,7 +102,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(mpAgentLoginPage.getFailedAuthenticationText());
+      mpAgentLoginPage.assertBodyContainsText(mpAgentLoginPage.getFailedAuthenticationText());
       mpAgentLoginPage.assertPageLocation();
     });
 
@@ -113,7 +113,7 @@ describe(
         password: staticFixtures.defaultPassword,
       });
 
-      cy.contains(mpAgentLoginPage.getFailedAuthenticationText());
+      mpAgentLoginPage.assertBodyContainsText(mpAgentLoginPage.getFailedAuthenticationText());
       mpAgentLoginPage.assertPageLocation();
     });
 
@@ -130,8 +130,8 @@ describe(
     it('agent assist login page in MP should not contain "Forgot password" button', (): void => {
       mpAgentLoginPage.visit();
 
-      cy.contains('Agent Assist Login');
-      cy.get('body').contains('Forgot password').should('not.exist');
+      mpAgentLoginPage.assertBodyContainsText('Agent Assist Login');
+      mpAgentLoginPage.assertBodyContainsText('Forgot password').should('not.exist');
     });
   }
 );

--- a/cypress/e2e/mp/marketplace-agent-assist/agent-merchant-portal.cy.ts
+++ b/cypress/e2e/mp/marketplace-agent-assist/agent-merchant-portal.cy.ts
@@ -104,7 +104,7 @@ describe(
       profilePage.visit({ failOnStatusCode: false }); // TODO: Fix JS error
       profilePage.updatePhone();
 
-      cy.get('body').contains('The Profile has been changed successfully.');
+      profilePage.assertBodyContainsText('The Profile has been changed successfully.');
     });
 
     it('agent should be able to modify product information during impersonation', (): void => {
@@ -126,7 +126,7 @@ describe(
 
       cy.get('@drawer').find(productsPage.getSaveButtonSelector()).click();
 
-      cy.get('body').contains('The Product is saved.');
+      productsPage.assertBodyContainsText('The Product is saved.');
     });
 
     it('agent should be able to modify offer information during impersonation', (): void => {
@@ -140,7 +140,7 @@ describe(
       offersPage.find({ query: dynamicFixtures.productOffer.product_offer_reference }).click({ force: true });
       offersPage.getDrawer().find(offersPage.getSaveButtonSelector()).click();
 
-      cy.get('body').contains('The Offer is saved.');
+      offersPage.assertBodyContainsText('The Offer is saved.');
     });
 
     function addOneProductToCart(): void {

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,7 +10,8 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
-  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+  assertBodyContainsText = (text: string, options?: Partial<Cypress.Timeoutable>): Cypress.Chainable =>
+    cy.get('body').contains(text, options);
 
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,5 +10,7 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
+  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }


### PR DESCRIPTION
## Summary

Clears 24 of the 165-violation `no-cy-get-outside-repository` backlog, scoped to the `mp/` domain across 5 spec files:

- `cypress/e2e/mp/data-import/merchant-combined-product.cy.ts` (1 site)
- `cypress/e2e/mp/marketplace-agent-assist/agent-authorization.cy.ts` (5 sites)
- `cypress/e2e/mp/marketplace-agent-assist/agent-dashboard.cy.ts` (6 sites)
- `cypress/e2e/mp/marketplace-agent-assist/agent-login.cy.ts` (9 sites)
- `cypress/e2e/mp/marketplace-agent-assist/agent-merchant-portal.cy.ts` (3 of its 6 sites)

All are bare `cy.contains()` / `cy.get('body').contains()` text-visibility assertions, replaced with the already in-scope page object's `assertBodyContainsText()` call.

`agent-merchant-portal.cy.ts` is split with a sibling PR: this PR only touches lines 107/129/143 (plain text-assertion sites). Lines ~117-128 (a `cy.get('@drawer')` alias chain needing a genuinely new page-object method) are being handled in a separate PR/worktree. Expect a trivial rebase on whichever of the two merges second.

Also duplicates the one-line `assertBodyContainsText` helper on `AbstractPage` from PR #346 (not yet merged, and this branch wasn't stacked on it) so this branch lints/typechecks standalone. Becomes a no-op once #346 merges.

## Test plan

- [x] `npm run lint` — zero remaining `no-cy-get-outside-repository` violations on every fixed line; `agent-merchant-portal.cy.ts` still shows the 3 expected out-of-scope violations at lines 122/125/127; no new violations of other rules introduced
- [x] `npm run typecheck` — passes
- [ ] Live spec run against a Cypress-target docker stack — not possible this session (no matching stack available); open follow-up