### PR TITLE
CC-39568 Fix no-cy-get-outside-repository violations in smoke specs

### DIFF
--- a/cypress/e2e/smoke/catalog/product-search.cy.ts
+++ b/cypress/e2e/smoke/catalog/product-search.cy.ts
@@ -59,7 +59,7 @@ describe(
     });
 
     function assertProductDetailInformation(): void {
-      cy.contains(staticFixtures.concreteProduct.name);
+      productPage.assertBodyContainsText(staticFixtures.concreteProduct.name);
 
       productPage.getProductConfigurator().should('contain', staticFixtures.productPrice);
       productPage.getProductConfigurator().should('contain', staticFixtures.concreteProduct.sku);

--- a/cypress/e2e/smoke/checkout/basic-checkout.cy.ts
+++ b/cypress/e2e/smoke/checkout/basic-checkout.cy.ts
@@ -23,7 +23,7 @@ describe('basic checkout', { tags: ['@smoke', '@checkout', 'checkout', 'shipment
     addTwoProductsToCart();
     checkoutScenario.execute({ isGuest: true, paymentMethod: getPaymentMethodBasedOnEnv() });
 
-    cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+    customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
   });
 
   skipB2BIt('guest customer should checkout to multi shipment address', (): void => {
@@ -34,7 +34,7 @@ describe('basic checkout', { tags: ['@smoke', '@checkout', 'checkout', 'shipment
       paymentMethod: getPaymentMethodBasedOnEnv(),
     });
 
-    cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+    customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
   });
 
   skipB2BMpIt('customer should checkout to single shipment (with new shipping address)', (): void => {
@@ -46,7 +46,7 @@ describe('basic checkout', { tags: ['@smoke', '@checkout', 'checkout', 'shipment
     addTwoProductsToCart();
     checkoutScenario.execute({ paymentMethod: getPaymentMethodBasedOnEnv() });
 
-    cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+    customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
   });
 
   it('customer should checkout to multi shipment address (with new shipping address)', (): void => {
@@ -58,7 +58,7 @@ describe('basic checkout', { tags: ['@smoke', '@checkout', 'checkout', 'shipment
     addTwoProductsToCart();
     checkoutScenario.execute({ isMultiShipment: true, paymentMethod: getPaymentMethodBasedOnEnv() });
 
-    cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+    customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     //check for making sure session is not invalidated after checkout
     customerOverviewPage.viewLastPlacedOrder();
   });

--- a/cypress/e2e/smoke/order-management/dummy-payment-oms-flow.cy.ts
+++ b/cypress/e2e/smoke/order-management/dummy-payment-oms-flow.cy.ts
@@ -48,7 +48,7 @@ describe(
       addOneProductToCart();
       checkoutScenario.execute({ isGuest: true });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
 
       userLoginScenario.execute({
         username: staticFixtures.rootUser.username,
@@ -70,7 +70,7 @@ describe(
       addOneProductToCart();
       checkoutScenario.execute();
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
 
       userLoginScenario.execute({
         username: staticFixtures.rootUser.username,

--- a/cypress/e2e/smoke/product/publish-and-synchronize.cy.ts
+++ b/cypress/e2e/smoke/product/publish-and-synchronize.cy.ts
@@ -41,14 +41,14 @@ describe(
       cy.wait(5000); // For some reason URL still not synced in Redis, and after search, we need to wait a bit
       catalogPage.search({ query: productAbstract.name });
 
-      cy.contains(productAbstract.name);
-      cy.contains(productAbstract.sku);
-      cy.contains(productAbstract.description);
+      catalogPage.assertBodyContainsText(productAbstract.name);
+      catalogPage.assertBodyContainsText(productAbstract.sku);
+      catalogPage.assertBodyContainsText(productAbstract.description);
 
       if (!['b2b', 'b2b-mp'].includes(Cypress.env('repositoryId'))) {
-        cy.contains(productAbstract.price);
+        catalogPage.assertBodyContainsText(productAbstract.price);
         productPage.addToCart();
-        cy.contains(productPage.getAddToCartSuccessMessage());
+        productPage.assertBodyContainsText(productPage.getAddToCartSuccessMessage());
       }
     });
 
@@ -65,13 +65,13 @@ describe(
       cy.wait(5000); // For some reason URL still not synced in Redis, and after search, we need to wait a bit
       catalogPage.search({ query: productAbstract.name });
 
-      cy.contains(productAbstract.name);
-      cy.contains(productAbstract.sku);
-      cy.contains(productAbstract.description);
-      cy.contains(productAbstract.price);
+      catalogPage.assertBodyContainsText(productAbstract.name);
+      catalogPage.assertBodyContainsText(productAbstract.sku);
+      catalogPage.assertBodyContainsText(productAbstract.description);
+      catalogPage.assertBodyContainsText(productAbstract.price);
 
       productPage.addToCart();
-      cy.contains(productPage.getAddToCartSuccessMessage());
+      productPage.assertBodyContainsText(productPage.getAddToCartSuccessMessage());
     });
   }
 );

--- a/cypress/e2e/smoke/ssp/ssp-asset-create.cy.ts
+++ b/cypress/e2e/smoke/ssp/ssp-asset-create.cy.ts
@@ -43,7 +43,7 @@ describe(
         image: staticFixtures.asset.image,
       });
 
-      cy.contains(assetCreatePage.getAssetCreatedMessage());
+      assetCreatePage.assertBodyContainsText(assetCreatePage.getAssetCreatedMessage());
 
       assetDetailPage.assertPageLocation();
 

--- a/cypress/e2e/smoke/ssp/ssp-file-upload.cy.ts
+++ b/cypress/e2e/smoke/ssp/ssp-file-upload.cy.ts
@@ -55,7 +55,7 @@ describe(
       sspFileManagementListPage.visit();
       sspFileManagementListPage.verifyListPage();
       sspFileManagementListPage.searchFile(staticFixtures.uploadedFileName);
-      cy.contains(staticFixtures.uploadedFileName).should('exist');
+      sspFileManagementListPage.assertBodyContainsText(staticFixtures.uploadedFileName).should('exist');
     });
   }
 );

--- a/cypress/e2e/smoke/ssp/ssp-inquiry-create.cy.ts
+++ b/cypress/e2e/smoke/ssp/ssp-inquiry-create.cy.ts
@@ -39,10 +39,10 @@ describe(
       staticFixtures.generalSspInquiry.availableTypes = staticFixtures.sspInquiryTypes.general;
       sspInquiryCreatePage.createSspInquiry(staticFixtures.generalSspInquiry);
 
-      cy.contains(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
+      sspInquiryCreatePage.assertBodyContainsText(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
 
       sspInquiryListPage.visit();
-      cy.contains(staticFixtures.generalSspInquiry.subject).should('exist');
+      sspInquiryListPage.assertBodyContainsText(staticFixtures.generalSspInquiry.subject).should('exist');
     });
   }
 );

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,7 +10,8 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
-  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+  assertBodyContainsText = (text: string, options?: Partial<Cypress.Timeoutable>): Cypress.Chainable =>
+    cy.get('body').contains(text, options);
 
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,5 +10,7 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
+  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }


### PR DESCRIPTION
## Summary

Fixes all 21 `spryker-cypress/no-cy-get-outside-repository` violations in the `smoke/` domain (7 spec files) by routing raw `cy.get()`/`cy.contains()` calls through existing page-object methods instead. No new page-object wrapper methods were needed — every site fit either:
- Pattern A: bare text assertion -> `<pageObject>.assertBodyContainsText(text)`
- Pattern B (text): `cy.contains(xPage.getYMessage())` -> `xPage.assertBodyContainsText(xPage.getYMessage())`

Also adds the `assertBodyContainsText` helper to `cypress/support/pages/abstract-page.ts`, duplicating the one-liner already added on sibling PR #346 (`cc-39568-eslint-cleanup-abstract-page-helper`, not yet merged). This branch was cut directly from `eslint-plugin-spryker-cypress` rather than stacked on #346, so the helper is needed here for this branch to lint/typecheck standalone. Once #346 merges into this branch's base, the duplicate addition here collapses to a no-op.

Files touched:
- `cypress/e2e/smoke/catalog/product-search.cy.ts`
- `cypress/e2e/smoke/checkout/basic-checkout.cy.ts`
- `cypress/e2e/smoke/order-management/dummy-payment-oms-flow.cy.ts`
- `cypress/e2e/smoke/product/publish-and-synchronize.cy.ts`
- `cypress/e2e/smoke/ssp/ssp-asset-create.cy.ts`
- `cypress/e2e/smoke/ssp/ssp-file-upload.cy.ts`
- `cypress/e2e/smoke/ssp/ssp-inquiry-create.cy.ts`
- `cypress/support/pages/abstract-page.ts`

Out of scope: `smoke/ssp/ssp-model-create.cy.ts` (1 violation, image selector, handled in a separate PR).

## Test plan

- [x] `npm run lint` — 0 `no-cy-get-outside-repository` violations remain in any touched file; repo-wide count dropped from 165 to 144 (exactly the 21 fixed here); no new violations of other rules introduced by these changes
- [x] `npm run typecheck` — passes clean
- [ ] Live spec run against a Cypress-target docker stack — **not possible this session** (no matching stack available; open follow-up item)