### PR TITLE
CC-39568 Fix no-cy-get-outside-repository violations in backoffice specs

### DIFF
--- a/cypress/e2e/backoffice/category/category-edit.cy.ts
+++ b/cypress/e2e/backoffice/category/category-edit.cy.ts
@@ -26,12 +26,12 @@ describe(
 
     it('Backoffice user should not see store help text for parent', (): void => {
       goToCategoryEditPage(staticFixtures.rootCategoryName);
-      cy.get('body').contains(staticFixtures.helpText).should('not.exist');
+      categoryListPage.assertBodyContainsText(staticFixtures.helpText).should('not.exist');
     });
 
     it('Backoffice user should see store help text for child category', (): void => {
       goToCategoryEditPage(dynamicFixtures.childCategory.category_key);
-      cy.get('body').contains(staticFixtures.helpText);
+      categoryListPage.assertBodyContainsText(staticFixtures.helpText);
     });
 
     function goToCategoryEditPage(categorySearchQuery: string): void {

--- a/cypress/e2e/backoffice/gift-cards/order-gift-card.cy.ts
+++ b/cypress/e2e/backoffice/gift-cards/order-gift-card.cy.ts
@@ -52,7 +52,7 @@ describe(
         shouldSkipShipmentStep: true,
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
 
       userLoginScenario.execute({
         username: dynamicFixtures.rootUser.username,
@@ -67,7 +67,7 @@ describe(
       salesDetailPage.triggerOms({ state: 'Skip timeout', shouldTriggerOmsInCli: true });
       salesDetailPage.triggerOms({ state: 'Close' });
 
-      cy.contains('Status change triggered successfully.');
+      salesDetailPage.assertBodyContainsText('Status change triggered successfully.');
     });
   }
 );

--- a/cypress/e2e/backoffice/merchant-b2b-contract-requests/request-management.cy.ts
+++ b/cypress/e2e/backoffice/merchant-b2b-contract-requests/request-management.cy.ts
@@ -58,7 +58,7 @@ describe(
           idMerchant: merchant.id_merchant,
         });
 
-        cy.contains(merchant.name);
+        merchantRelationRequestListPage.assertBodyContainsText(merchant.name);
       });
     });
 
@@ -70,8 +70,8 @@ describe(
         idRelationRequest: dynamicFixtures.requestFromMerchant1.id_merchant_relation_request,
       });
 
-      cy.contains(staticFixtures.internalCommentFromMerchantUser1);
-      cy.contains(staticFixtures.internalCommentFromMerchantUser2);
+      merchantRelationRequestListPage.assertBodyContainsText(staticFixtures.internalCommentFromMerchantUser1);
+      merchantRelationRequestListPage.assertBodyContainsText(staticFixtures.internalCommentFromMerchantUser2);
     });
 
     it('operator should be able to add internal comment', (): void => {
@@ -91,7 +91,7 @@ describe(
         idRelationRequest: dynamicFixtures.requestFromMerchant1.id_merchant_relation_request,
       });
 
-      cy.contains(staticFixtures.internalCommentFromRootUser);
+      merchantRelationRequestListPage.assertBodyContainsText(staticFixtures.internalCommentFromRootUser);
     });
 
     it('operator should be able to add internal comment with emoji', (): void => {
@@ -111,7 +111,7 @@ describe(
         idMerchant: dynamicFixtures.merchant1.id_merchant,
       });
 
-      cy.contains(staticFixtures.internalCommentFromRootUserWithEmoji);
+      merchantRelationRequestListPage.assertBodyContainsText(staticFixtures.internalCommentFromRootUserWithEmoji);
     });
 
     it('operator should be able to reject request', (): void => {
@@ -129,7 +129,7 @@ describe(
         idMerchant: dynamicFixtures.merchant3.id_merchant,
       });
 
-      cy.contains('Rejected');
+      merchantRelationRequestListPage.assertBodyContainsText('Rejected');
 
       merchantRelationshipListPage.visit();
       merchantRelationshipListPage.applyFilters({ idCompany: dynamicFixtures.company2.id_company });
@@ -152,13 +152,13 @@ describe(
         idMerchant: dynamicFixtures.merchant1.id_merchant,
         idRelationRequest: dynamicFixtures.requestFromMerchant1.id_merchant_relation_request,
       });
-      cy.contains('Approved');
+      merchantRelationRequestListPage.assertBodyContainsText('Approved');
 
       merchantRelationshipListPage.visit();
       merchantRelationshipListPage.update({ idCompany: dynamicFixtures.company1.id_company });
 
-      cy.contains(staticFixtures.internalCommentFromMerchantUser1);
-      cy.contains(staticFixtures.internalCommentFromMerchantUser2);
+      merchantRelationshipListPage.assertBodyContainsText(staticFixtures.internalCommentFromMerchantUser1);
+      merchantRelationshipListPage.assertBodyContainsText(staticFixtures.internalCommentFromMerchantUser2);
     });
 
     it('operator should be able to approve request with enabled BU splitting', (): void => {
@@ -177,7 +177,7 @@ describe(
         idMerchant: dynamicFixtures.merchant2.id_merchant,
         idRelationRequest: dynamicFixtures.requestFromMerchant2.id_merchant_relation_request,
       });
-      cy.contains('Approved');
+      merchantRelationRequestListPage.assertBodyContainsText('Approved');
 
       merchantRelationshipListPage.visit();
       merchantRelationshipListPage.applyFilters({ idCompany: dynamicFixtures.company2.id_company });

--- a/cypress/e2e/backoffice/order-management/custom-order-reference-management.cy.ts
+++ b/cypress/e2e/backoffice/order-management/custom-order-reference-management.cy.ts
@@ -52,7 +52,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED') ? true : false,
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
 
       userLoginScenario.execute({
         username: dynamicFixtures.rootUser.username,
@@ -62,7 +62,7 @@ describe(
       salesIndexPage.visit();
       salesIndexPage.view();
 
-      cy.get('body').contains(staticFixtures.orderReference);
+      salesIndexPage.assertBodyContainsText(staticFixtures.orderReference);
     });
 
     function getPaymentMethodBasedOnEnv(): string {

--- a/cypress/e2e/backoffice/order-management/order-creation.cy.ts
+++ b/cypress/e2e/backoffice/order-management/order-creation.cy.ts
@@ -47,7 +47,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
 
       userLoginScenario.execute({
         username: dynamicFixtures.rootUser.username,
@@ -57,7 +57,7 @@ describe(
       salesIndexPage.visit();
       salesIndexPage.view();
 
-      cy.get('body').contains(dynamicFixtures.product.sku);
+      salesIndexPage.assertBodyContainsText(dynamicFixtures.product.sku);
     });
 
     skipB2BIt('should be able to create an order by guest (credit card)', (): void => {
@@ -68,7 +68,7 @@ describe(
         paymentMethod: 'dummyPaymentCreditCard',
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
 
       userLoginScenario.execute({
         username: dynamicFixtures.rootUser.username,
@@ -78,7 +78,7 @@ describe(
       salesIndexPage.visit();
       salesIndexPage.view();
 
-      cy.get('body').contains(dynamicFixtures.product.sku);
+      salesIndexPage.assertBodyContainsText(dynamicFixtures.product.sku);
     });
 
     function getPaymentMethodBasedOnEnv(): string {

--- a/cypress/e2e/backoffice/return-management/return-creation.cy.ts
+++ b/cypress/e2e/backoffice/return-management/return-creation.cy.ts
@@ -77,7 +77,7 @@ describe(
       salesDetailPage.create();
       salesReturnCreatePage.create();
 
-      cy.contains('Return was successfully created.');
+      salesReturnCreatePage.assertBodyContainsText('Return was successfully created.');
     });
 
     it('should be able to create return from (from delivery order state)', (): void => {
@@ -94,7 +94,7 @@ describe(
       salesDetailPage.create();
       salesReturnCreatePage.create();
 
-      cy.contains('Return was successfully created.');
+      salesReturnCreatePage.assertBodyContainsText('Return was successfully created.');
     });
 
     function addOneProductToCart(): void {

--- a/cypress/e2e/backoffice/ssp-inquiry/ssp-inquiry-view.cy.ts
+++ b/cypress/e2e/backoffice/ssp-inquiry/ssp-inquiry-view.cy.ts
@@ -126,7 +126,7 @@ describe(
       sspInquiryDetailPage.submitComment('This is a test comment.');
 
       sspInquiryDetailPage.assertPageLocation();
-      cy.contains('This is a test comment.').should('exist');
+      sspInquiryDetailPage.assertBodyContainsText('This is a test comment.').should('exist');
     });
 
     it('should visit the ssp inquiry list page', () => {

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,7 +10,8 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
-  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+  assertBodyContainsText = (text: string, options?: Partial<Cypress.Timeoutable>): Cypress.Chainable =>
+    cy.get('body').contains(text, options);
 
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,5 +10,7 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
+  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }


### PR DESCRIPTION
## Summary
- Fixes all 23 `spryker-cypress/no-cy-get-outside-repository` violations in the `backoffice/` domain, across 7 spec files: `category-edit.cy.ts`, `order-gift-card.cy.ts`, `request-management.cy.ts`, `custom-order-reference-management.cy.ts`, `order-creation.cy.ts`, `return-creation.cy.ts`, `ssp-inquiry-view.cy.ts`.
- Bare `cy.get('body').contains(...)` / `cy.contains(...)` calls replaced with the in-scope page object's `assertBodyContainsText(text)` method (new helper on `AbstractPage`).
- Adds the same one-line `assertBodyContainsText` helper to `cypress/support/pages/abstract-page.ts` that PR #346 already introduces. This branch was cut directly from `eslint-plugin-spryker-cypress` (not stacked on #346), so the duplication is intentional to keep this branch lint/typecheck-clean standalone. It collapses to a no-op once #346 merges — no follow-up needed.
- Out of scope: `backoffice/configuration/configuration.cy.ts`, `backoffice/configuration/configuration-management.cy.ts`, `backoffice/product-management/product-attachment-management.cy.ts` (handled by a separate Pattern-C PR).

## Test plan
- [x] `npm run lint` — 0 remaining `no-cy-get-outside-repository` violations in all 7 touched spec files; no new violations of any other rule introduced (598 pre-existing warnings elsewhere in the repo, unrelated to this change, unchanged in kind).
- [x] `npm run typecheck` — passes with no errors.
- [ ] Live spec run against a Cypress-target stack — **not possible this session** (no matching docker stack was up; only unrelated `spryker-lab` and another engineer's `wt2_*` suite worktree stack were running). This is a refactor of assertion plumbing only, so lint+typecheck passing does not guarantee the moved assertions still pass at runtime — flagged as an open follow-up.