### PR TITLE
CC-39568 Fix no-cy-get-outside-repository violations in yves checkout/catalog/product specs

### DIFF
--- a/cypress/e2e/yves/catalog/product-search-dms.cy.ts
+++ b/cypress/e2e/yves/catalog/product-search-dms.cy.ts
@@ -87,7 +87,7 @@ describe(
     });
 
     function assertProductDetailInformation(): void {
-      cy.contains(dynamicFixtures.product.localized_attributes[0].name);
+      productPage.assertBodyContainsText(dynamicFixtures.product.localized_attributes[0].name);
       productPage.getProductConfigurator().should('contain', staticFixtures.productPrice);
       productPage.getProductConfigurator().should('contain', dynamicFixtures.product.sku);
     }

--- a/cypress/e2e/yves/checkout/basic-checkout-dms.cy.ts
+++ b/cypress/e2e/yves/checkout/basic-checkout-dms.cy.ts
@@ -60,7 +60,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     skipB2BIt('guest customer should checkout to multi shipment address', (): void => {
@@ -73,7 +73,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to single shipment (with customer shipping address)', (): void => {
@@ -91,7 +91,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to single shipment (with new shipping address)', (): void => {
@@ -109,7 +109,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED'),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
@@ -128,7 +128,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to multi shipment address (with new shipping address)', (): void => {
@@ -146,7 +146,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     function getPaymentMethodBasedOnEnv(): string {

--- a/cypress/e2e/yves/checkout/basic-checkout.cy.ts
+++ b/cypress/e2e/yves/checkout/basic-checkout.cy.ts
@@ -28,7 +28,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     skipB2BIt('guest customer should checkout to multi shipment address', (): void => {
@@ -40,7 +40,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to single shipment (with customer shipping address)', (): void => {
@@ -61,7 +61,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED') ? true : false,
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to single shipment (with new shipping address)', (): void => {
@@ -81,7 +81,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED') ? true : false,
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
@@ -102,7 +102,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     it('customer should checkout to multi shipment address (with new shipping address)', (): void => {
@@ -122,7 +122,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
     });
 
     function getPaymentMethodBasedOnEnv(): string {

--- a/cypress/e2e/yves/checkout/basic-checkout.cy.ts
+++ b/cypress/e2e/yves/checkout/basic-checkout.cy.ts
@@ -28,7 +28,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     skipB2BIt('guest customer should checkout to multi shipment address', (): void => {
@@ -40,7 +40,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to single shipment (with customer shipping address)', (): void => {
@@ -61,7 +61,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED') ? true : false,
       });
 
-      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to single shipment (with new shipping address)', (): void => {
@@ -81,7 +81,7 @@ describe(
         isMultiShipment: Cypress.env('ENV_IS_SSP_ENABLED') ? true : false,
       });
 
-      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to multi shipment address (with customer shipping address)', (): void => {
@@ -102,7 +102,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     it('customer should checkout to multi shipment address (with new shipping address)', (): void => {
@@ -122,7 +122,7 @@ describe(
         paymentMethod: getPaymentMethodBasedOnEnv(),
       });
 
-      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 });
     });
 
     function getPaymentMethodBasedOnEnv(): string {

--- a/cypress/e2e/yves/cms/cms-page-search-dms.cy.ts
+++ b/cypress/e2e/yves/cms/cms-page-search-dms.cy.ts
@@ -61,7 +61,7 @@ describe(
 
       cy.url().should('match', regex);
 
-      cy.contains(staticFixtures.cmsPageName).should('exist');
+      contentPage.assertBodyContainsText(staticFixtures.cmsPageName).should('exist');
     }
 
     function createStoreAndCmsPage(): void {

--- a/cypress/e2e/yves/merchant-b2b-contract-requests/request-management.cy.ts
+++ b/cypress/e2e/yves/merchant-b2b-contract-requests/request-management.cy.ts
@@ -61,7 +61,7 @@ describe(
       merchantRelationRequestIndexPage.filterRequests({ status: 'rejected' });
       merchantRelationRequestIndexPage.openFirstRequest();
 
-      cy.contains(staticFixtures.decisionNote);
+      merchantRelationRequestDetailsPage.assertBodyContainsText(staticFixtures.decisionNote);
     });
 
     it('company user should be able to filter MR requests by status', (): void => {

--- a/cypress/e2e/yves/product/publish-and-synchronize-dms.cy.ts
+++ b/cypress/e2e/yves/product/publish-and-synchronize-dms.cy.ts
@@ -76,19 +76,19 @@ describe(
 
       catalogPage.search({ query: productAbstract.name });
 
-      cy.contains(productAbstract.name);
-      cy.contains(productAbstract.sku);
-      cy.contains(productAbstract.description);
-      cy.get('body').should('satisfy', ($body) => {
+      catalogPage.assertBodyContainsText(productAbstract.name);
+      catalogPage.assertBodyContainsText(productAbstract.sku);
+      catalogPage.assertBodyContainsText(productAbstract.description);
+      catalogPage.getBody().should('satisfy', ($body) => {
         const text = $body.text();
         // Number of in stock items or Available (never out of stock)
         return text.includes('Available') || /\d+(\.\d+)?\s+in stock/.test(text);
       });
 
       if (!['b2b', 'b2b-mp'].includes(Cypress.env('repositoryId'))) {
-        cy.contains(productAbstract.price);
+        catalogPage.assertBodyContainsText(productAbstract.price);
         productPage.addToCart();
-        cy.contains(productPage.getAddToCartSuccessMessage());
+        productPage.assertBodyContainsText(productPage.getAddToCartSuccessMessage());
       }
     });
 
@@ -104,18 +104,18 @@ describe(
 
       catalogPage.search({ query: productAbstract.name });
 
-      cy.contains(productAbstract.name);
-      cy.contains(productAbstract.sku);
-      cy.contains(productAbstract.description);
-      cy.get('body').should('satisfy', ($body) => {
+      catalogPage.assertBodyContainsText(productAbstract.name);
+      catalogPage.assertBodyContainsText(productAbstract.sku);
+      catalogPage.assertBodyContainsText(productAbstract.description);
+      catalogPage.getBody().should('satisfy', ($body) => {
         const text = $body.text();
         // Number of in stock items or Available (never out of stock)
         return text.includes('Available') || /\d+(\.\d+)?\s+in stock/.test(text);
       });
-      cy.contains(productAbstract.price);
+      catalogPage.assertBodyContainsText(productAbstract.price);
 
       productPage.addToCart();
-      cy.contains(productPage.getAddToCartSuccessMessage());
+      productPage.assertBodyContainsText(productPage.getAddToCartSuccessMessage());
     });
   }
 );

--- a/cypress/e2e/yves/product/publish-and-synchronize.cy.ts
+++ b/cypress/e2e/yves/product/publish-and-synchronize.cy.ts
@@ -51,14 +51,14 @@ describe(
 
       catalogPage.search({ query: productAbstract.name });
 
-      cy.contains(productAbstract.name);
-      cy.contains(productAbstract.sku);
-      cy.contains(productAbstract.description);
+      catalogPage.assertBodyContainsText(productAbstract.name);
+      catalogPage.assertBodyContainsText(productAbstract.sku);
+      catalogPage.assertBodyContainsText(productAbstract.description);
 
       if (!['b2b', 'b2b-mp'].includes(Cypress.env('repositoryId'))) {
-        cy.contains(productAbstract.price);
+        catalogPage.assertBodyContainsText(productAbstract.price);
         productPage.addToCart();
-        cy.contains(productPage.getAddToCartSuccessMessage());
+        productPage.assertBodyContainsText(productPage.getAddToCartSuccessMessage());
       }
     });
 
@@ -73,13 +73,13 @@ describe(
 
       catalogPage.search({ query: productAbstract.name });
 
-      cy.contains(productAbstract.name);
-      cy.contains(productAbstract.sku);
-      cy.contains(productAbstract.description);
-      cy.contains(productAbstract.price);
+      catalogPage.assertBodyContainsText(productAbstract.name);
+      catalogPage.assertBodyContainsText(productAbstract.sku);
+      catalogPage.assertBodyContainsText(productAbstract.description);
+      catalogPage.assertBodyContainsText(productAbstract.price);
 
       productPage.addToCart();
-      cy.contains(productPage.getAddToCartSuccessMessage());
+      productPage.assertBodyContainsText(productPage.getAddToCartSuccessMessage());
     });
   }
 );

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,7 +10,8 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
-  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+  assertBodyContainsText = (text: string, options?: Partial<Cypress.Timeoutable>): Cypress.Chainable =>
+    cy.get('body').contains(text, options);
 
   getBody = (): Cypress.Chainable => cy.get('body');
 

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,5 +10,9 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
+  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+
+  getBody = (): Cypress.Chainable => cy.get('body');
+
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }


### PR DESCRIPTION
## Summary

- Fixes all 37 `spryker-cypress/no-cy-get-outside-repository` violations across 7 yves spec files (checkout basic-checkout / basic-checkout-dms, catalog product-search-dms, cms cms-page-search-dms, merchant-b2b-contract-requests request-management, product publish-and-synchronize / publish-and-synchronize-dms), by routing raw `cy.get()`/`cy.contains()` calls through page-object methods (`assertBodyContainsText`, a new `getBody` wrapper, both on `AbstractPage`).
- This branch was cut directly from `eslint-plugin-spryker-cypress` (not stacked on #346), so it duplicates the one-line `assertBodyContainsText` helper from sibling PR #346 onto `AbstractPage` so this branch lints/typechecks standalone. This collapses to a no-op once #346 merges.
- This is the checkout/catalog/product half of the yves domain backlog; a sibling PR (separate branch) covers the rest (customer-account-management, order-amendment, product-comparison, reorder/*, ssp-asset, ssp-inquiry).
- **Follow-up fix**: `basic-checkout.cy.ts` originally called `cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage(), { timeout: 15000 })` at 6 sites — an explicit 15s timeout for the order-confirmation banner. The initial mechanical fix silently dropped that to Cypress's default timeout. Fixed by extending `assertBodyContainsText` to accept optional `Cypress.Timeoutable` (mirrored into #346 and all sibling branches) and restoring `{ timeout: 15000 }` on those 6 call sites.

## Test plan

- [x] `npm run lint` — zero remaining `no-cy-get-outside-repository` violations in all touched files, no new violations of other rules
- [x] `npm run typecheck` — passes
- [x] Checkout-confirmation timeout regression caught and fixed (see above)
- [ ] Live spec run against a Cypress-target docker stack — **not possible this session** (no available/matching stack; this batch is checkout-flow-heavy, so live verification is an important open follow-up before merging)