### PR TITLE
CC-39568 Fix no-cy-get-outside-repository violations in yves account/reorder/ssp specs

### DIFF
--- a/cypress/e2e/yves/customer-account-management/customer-auth-dms.cy.ts
+++ b/cypress/e2e/yves/customer-account-management/customer-auth-dms.cy.ts
@@ -62,7 +62,7 @@ describe(
     skipB2BIt('guest should be able to register and login as new customer', (): void => {
       loginPage.visit();
       const registeredCustomer = loginPage.register();
-      cy.contains(loginPage.getRegistrationCompletedMessage());
+      loginPage.assertBodyContainsText(loginPage.getRegistrationCompletedMessage());
 
       loginPage.login({ email: registeredCustomer.email, password: registeredCustomer.password });
       customerOverviewPage.assertPageLocation();

--- a/cypress/e2e/yves/customer-account-management/customer-auth.cy.ts
+++ b/cypress/e2e/yves/customer-account-management/customer-auth.cy.ts
@@ -28,7 +28,7 @@ describe(
     skipB2BIt('guest should be able to register and login as new customer', (): void => {
       loginPage.visit();
       const registeredCustomer = loginPage.register();
-      cy.contains(loginPage.getRegistrationCompletedMessage());
+      loginPage.assertBodyContainsText(loginPage.getRegistrationCompletedMessage());
 
       loginPage.login({ email: registeredCustomer.email, password: registeredCustomer.password });
       customerOverviewPage.assertPageLocation();

--- a/cypress/e2e/yves/order-amendment/order-amendment-start.cy.ts
+++ b/cypress/e2e/yves/order-amendment/order-amendment-start.cy.ts
@@ -63,7 +63,7 @@ describe(
 
         cartPage.assertPageLocation();
         cartPage.assertCartName(isB2c() ? 'In Your Cart' : `Editing Order ${orderReference}`);
-        cy.get('body').contains(dynamicFixtures.product.localized_attributes[0].name).should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product.localized_attributes[0].name).should('exist');
 
         customerOverviewPage.viewLastPlacedOrder();
         orderDetailsPage.containsOrderState('Editing in Progress');
@@ -137,7 +137,7 @@ describe(
 
         cartPage.assertPageLocation();
         cartPage.assertCartName(isB2c() ? 'In Your Cart' : `Editing Order ${orderReference}`);
-        cy.get('body').contains(dynamicFixtures.product.localized_attributes[0].name).should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product.localized_attributes[0].name).should('exist');
 
         customerOverviewPage.viewLastPlacedOrder();
         orderDetailsPage.containsOrderState('Editing in Progress');
@@ -172,7 +172,7 @@ describe(
 
         cartPage.assertPageLocation();
         cartPage.assertCartName(isB2c() ? 'In Your Cart' : `Editing Order ${orderReference}`);
-        cy.get('body').contains(dynamicFixtures.product.localized_attributes[0].name).should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product.localized_attributes[0].name).should('exist');
 
         customerOverviewPage.viewLastPlacedOrder();
         orderDetailsPage.containsOrderState('Editing in Progress');
@@ -217,7 +217,9 @@ describe(
 
         cartPage.changeQuantity({ sku: dynamicFixtures.productOutOfStock2.sku, quantity: 2 });
 
-        cy.contains(`Item ${dynamicFixtures.productOutOfStock2.sku} only has availability of 1.`).should('exist');
+        cartPage
+          .assertBodyContainsText(`Item ${dynamicFixtures.productOutOfStock2.sku} only has availability of 1.`)
+          .should('exist');
         cartPage.getCartItemChangeQuantityField(dynamicFixtures.productOutOfStock2.sku).should('have.value', '1');
       });
     });

--- a/cypress/e2e/yves/product-comparison/product-comparison.cy.ts
+++ b/cypress/e2e/yves/product-comparison/product-comparison.cy.ts
@@ -27,10 +27,10 @@ describe(
 
     it('customer should be able to add product to comparison list', (): void => {
       addProductToComparisonList(dynamicFixtures.product1.abstract_sku);
-      cy.contains(productPage.getAddToComparisonListSuccessMessage());
+      productPage.assertBodyContainsText(productPage.getAddToComparisonListSuccessMessage());
 
-      cy.get(productComparisonPage.getComparisonPageNavigationLinkSelector()).click({ force: true });
-      cy.get(productComparisonPage.getProductItemsSelector()).should('have.length', 1);
+      productComparisonPage.getComparisonPageNavigationLink().click({ force: true });
+      productComparisonPage.getProductItems().should('have.length', 1);
     });
 
     it('customer should be redirected to comparison page after adding two products', (): void => {
@@ -38,7 +38,7 @@ describe(
       addProductToComparisonList(dynamicFixtures.product2.abstract_sku);
 
       productComparisonPage.assertPageLocation();
-      cy.get(productComparisonPage.getProductItemsSelector()).should('have.length', 2);
+      productComparisonPage.getProductItems().should('have.length', 2);
     });
 
     it('customer should see product attributes comparison table', (): void => {
@@ -47,7 +47,7 @@ describe(
       addProductToComparisonList(dynamicFixtures.product3.abstract_sku);
       productComparisonPage.assertPageLocation();
 
-      cy.get(productComparisonPage.getComparisonTableRowSelector()).should('have.length', 3);
+      productComparisonPage.getComparisonTableRow().should('have.length', 3);
     });
 
     it('customer should be able to remove product from comparison list', (): void => {
@@ -59,7 +59,7 @@ describe(
       productComparisonPage.removeProductFromComparisonList(dynamicFixtures.product2.sku);
 
       productComparisonPage.assertPageLocation();
-      cy.get(productComparisonPage.getProductItemsSelector()).should('have.length', 2);
+      productComparisonPage.getProductItems().should('have.length', 2);
     });
 
     it('customer should be able to clear the product comparison list', (): void => {
@@ -71,18 +71,18 @@ describe(
       productComparisonPage.clearComparisonList();
 
       productComparisonPage.assertPageLocation();
-      cy.contains(productComparisonPage.getProductComparisonListIsEmptyMessage());
+      productComparisonPage.assertBodyContainsText(productComparisonPage.getProductComparisonListIsEmptyMessage());
     });
 
     it('customer should be able to remove product from comparison from PDP', (): void => {
       addProductToComparisonList(dynamicFixtures.product1.abstract_sku);
-      cy.contains(productPage.getAddToComparisonListSuccessMessage());
+      productPage.assertBodyContainsText(productPage.getAddToComparisonListSuccessMessage());
 
       productPage.toggleProductComparisonList();
-      cy.contains(productPage.getRemoveFromComparisonListSuccessMessage());
+      productPage.assertBodyContainsText(productPage.getRemoveFromComparisonListSuccessMessage());
 
-      cy.get(productComparisonPage.getComparisonPageNavigationLinkSelector()).click({ force: true, multiple: true });
-      cy.contains(productComparisonPage.getProductComparisonListIsEmptyMessage());
+      productComparisonPage.getComparisonPageNavigationLink().click({ force: true, multiple: true });
+      productComparisonPage.assertBodyContainsText(productComparisonPage.getProductComparisonListIsEmptyMessage());
     });
 
     it('customer should be able to add configured number of items to compare list', (): void => {
@@ -93,10 +93,10 @@ describe(
       catalogPage.searchProductFromSuggestions({ query: dynamicFixtures.product4.abstract_sku });
       productPage.toggleProductComparisonList();
 
-      cy.contains(productPage.getAddToComparisonListLimitExceededErrorMessage());
+      productPage.assertBodyContainsText(productPage.getAddToComparisonListLimitExceededErrorMessage());
 
-      cy.get(productComparisonPage.getComparisonPageNavigationLinkSelector()).click({ force: true });
-      cy.get(productComparisonPage.getProductItemsSelector()).should('have.length', 3);
+      productComparisonPage.getComparisonPageNavigationLink().click({ force: true });
+      productComparisonPage.getProductItems().should('have.length', 3);
     });
 
     function addProductToComparisonList(abstractSku: string): void {

--- a/cypress/e2e/yves/reorder/reorder-concrete-products.cy.ts
+++ b/cypress/e2e/yves/reorder/reorder-concrete-products.cy.ts
@@ -46,8 +46,8 @@ describe(
         cartPage.assertPageLocation();
         cartPage.assertCartName(isB2c() ? 'In Your Cart' : `Reorder from Order ${orderReference}`);
 
-        cy.get('body').contains(dynamicFixtures.product1.localized_attributes[0].name).should('exist');
-        cy.get('body').contains(dynamicFixtures.product2.localized_attributes[0].name).should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product1.localized_attributes[0].name).should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product2.localized_attributes[0].name).should('exist');
       });
     });
 
@@ -64,8 +64,8 @@ describe(
         cartPage.assertPageLocation();
         cartPage.assertCartName(isB2c() ? 'In Your Cart' : `Reorder from Order ${orderReference}`);
 
-        cy.get('body').contains(dynamicFixtures.product1.localized_attributes[0].name).should('exist');
-        cy.get('body').contains(dynamicFixtures.product2.localized_attributes[0].name).should('not.exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product1.localized_attributes[0].name).should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product2.localized_attributes[0].name).should('not.exist');
       });
     });
 
@@ -91,7 +91,7 @@ describe(
       customerOverviewPage.viewLastPlacedOrder();
       orderDetailsPage.reorderAll();
 
-      cy.get('body').contains(dynamicFixtures.productOptionValue.value).should('exist');
+      cartPage.assertBodyContainsText(dynamicFixtures.productOptionValue.value).should('exist');
     });
 
     function placeCustomerOrder(email: string, idCustomerAddress: number): void {

--- a/cypress/e2e/yves/reorder/reorder-product-bundles.cy.ts
+++ b/cypress/e2e/yves/reorder/reorder-product-bundles.cy.ts
@@ -43,7 +43,7 @@ describe(
       customerOverviewPage.viewLastPlacedOrder();
       orderDetailsPage.reorderAll();
 
-      cy.get('body').contains(dynamicFixtures.productBundle.localized_attributes[0].name).should('exist');
+      productPage.assertBodyContainsText(dynamicFixtures.productBundle.localized_attributes[0].name).should('exist');
     });
 
     function placeOrderWithProductBundle(): void {

--- a/cypress/e2e/yves/reorder/reorder-product-offers.cy.ts
+++ b/cypress/e2e/yves/reorder/reorder-product-offers.cy.ts
@@ -52,11 +52,15 @@ describe(
         cartPage.assertPageLocation();
         cartPage.assertCartName(isB2c() ? 'In Your Cart' : `Reorder from Order ${orderReference}`);
 
-        cy.get('body').contains(`${staticFixtures.soldByText} ${dynamicFixtures.merchant1.name}`).should('exist');
-        cy.get('body').contains(dynamicFixtures.product1.localized_attributes[0].name).should('exist');
+        cartPage
+          .assertBodyContainsText(`${staticFixtures.soldByText} ${dynamicFixtures.merchant1.name}`)
+          .should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product1.localized_attributes[0].name).should('exist');
 
-        cy.get('body').contains(`${staticFixtures.soldByText} ${dynamicFixtures.merchant2.name}`).should('exist');
-        cy.get('body').contains(dynamicFixtures.product2.localized_attributes[0].name).should('exist');
+        cartPage
+          .assertBodyContainsText(`${staticFixtures.soldByText} ${dynamicFixtures.merchant2.name}`)
+          .should('exist');
+        cartPage.assertBodyContainsText(dynamicFixtures.product2.localized_attributes[0].name).should('exist');
       });
     });
 

--- a/cypress/e2e/yves/reorder/reorder-random-weight-products.cy.ts
+++ b/cypress/e2e/yves/reorder/reorder-random-weight-products.cy.ts
@@ -50,8 +50,8 @@ describe(
       customerOverviewPage.viewLastPlacedOrder();
       orderDetailsPage.reorderAll();
 
-      cy.get('body').contains(dynamicFixtures.productMUnit.localized_attributes[0].name).should('exist');
-      cy.get('body').contains(dynamicFixtures.productPUnit.localized_attributes[0].name).should('exist');
+      cartPage.assertBodyContainsText(dynamicFixtures.productMUnit.localized_attributes[0].name).should('exist');
+      cartPage.assertBodyContainsText(dynamicFixtures.productPUnit.localized_attributes[0].name).should('exist');
     });
 
     function placeOrderWithRandomWeightProducts(): void {

--- a/cypress/e2e/yves/ssp-asset/ssp-asset.cy.ts
+++ b/cypress/e2e/yves/ssp-asset/ssp-asset.cy.ts
@@ -72,7 +72,7 @@ describe(
         image: staticFixtures.asset.image,
       });
 
-      cy.contains(assetCreatePage.getAssetCreatedMessage());
+      assetCreatePage.assertBodyContainsText(assetCreatePage.getAssetCreatedMessage());
 
       assetDetailPage.assertPageLocation();
 
@@ -116,7 +116,7 @@ describe(
         image: staticFixtures.assetUpdateData.image,
       });
 
-      cy.contains(assetEditPage.getAssetEditedMessage());
+      assetEditPage.assertBodyContainsText(assetEditPage.getAssetEditedMessage());
 
       assetDetailPage.visit({
         qs: {
@@ -200,7 +200,7 @@ describe(
 
         assetDetailPage.assertPageLocation();
 
-        cy.contains(assetReference).should('exist');
+        assetListPage.assertBodyContainsText(assetReference).should('exist');
       });
 
       assetListPage.visit();
@@ -361,7 +361,7 @@ describe(
 
       assetDetailPage.getUnassignLink().click();
       assetDetailPage.getUnassignButton().click();
-      cy.contains(assetDetailPage.getUnassignmentErrorMessage()).should('exist');
+      assetDetailPage.assertBodyContainsText(assetDetailPage.getUnassignmentErrorMessage()).should('exist');
 
       assetDetailPage.visit({
         qs: {
@@ -399,7 +399,7 @@ describe(
         idCustomerAddress: 0,
       });
 
-      cy.contains(customerOverviewPage.getPlacedOrderSuccessMessage());
+      customerOverviewPage.assertBodyContainsText(customerOverviewPage.getPlacedOrderSuccessMessage());
 
       customerOverviewPage.viewLastPlacedOrder();
 

--- a/cypress/e2e/yves/ssp-inquiry/ssp-inquiry.cy.ts
+++ b/cypress/e2e/yves/ssp-inquiry/ssp-inquiry.cy.ts
@@ -61,7 +61,7 @@ describe(
       sspInquiryCreatePage.createSspInquiry(staticFixtures.generalSspInquiry);
 
       sspInquiryDetailPage.assertPageLocation();
-      cy.contains(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
+      sspInquiryCreatePage.assertBodyContainsText(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
 
       sspInquiryListPage.visit();
 
@@ -114,7 +114,7 @@ describe(
       });
 
       sspInquiryDetailPage.assertPageLocation();
-      cy.contains(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
+      sspInquiryCreatePage.assertBodyContainsText(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
 
       sspInquiryListPage.visit();
       const sspInquiryReference = sspInquiryListPage.getFirstRowReference();
@@ -168,7 +168,7 @@ describe(
       });
 
       sspInquiryDetailPage.assertPageLocation();
-      cy.contains(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
+      sspInquiryCreatePage.assertBodyContainsText(sspInquiryCreatePage.getSspInquiryCreatedMessage()).should('exist');
 
       sspInquiryListPage.visit();
       const sspInquiryReference = sspInquiryListPage.getFirstRowReference();
@@ -216,7 +216,7 @@ describe(
       sspInquiryDetailPage.assertPageLocation();
       sspInquiryDetailPage.clickCancelSspInquiryButton();
 
-      cy.get(sspInquiryDetailPage.getCanceledSspInquiryStatusSelector()).should('exist');
+      sspInquiryDetailPage.getCanceledSspInquiryStatus().should('exist');
     });
 
     it('customer should not be able to cancel a ssp inquiry if he is now owner', (): void => {

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,7 +10,8 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
-  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+  assertBodyContainsText = (text: string, options?: Partial<Cypress.Timeoutable>): Cypress.Chainable =>
+    cy.get('body').contains(text, options);
 
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,5 +10,7 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
+  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/yves/product-comparison/product-comparison-page.ts
+++ b/cypress/support/pages/yves/product-comparison/product-comparison-page.ts
@@ -34,4 +34,16 @@ export class ProductComparisonPage extends YvesPage {
   getComparisonTableRowSelector = (): string => {
     return this.repository.getComparisonTableRowSelector();
   };
+
+  getComparisonPageNavigationLink = (): Cypress.Chainable => {
+    return cy.get(this.repository.getComparisonPageNavigationLinkSelector());
+  };
+
+  getProductItems = (): Cypress.Chainable => {
+    return cy.get(this.repository.getProductItemSelector());
+  };
+
+  getComparisonTableRow = (): Cypress.Chainable => {
+    return cy.get(this.repository.getComparisonTableRowSelector());
+  };
 }

--- a/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-detail-page.ts
+++ b/cypress/support/pages/yves/ssp-inquiry/ssp-inquiry-detail-page.ts
@@ -74,6 +74,10 @@ export class SspInquiryDetailPage extends YvesPage {
   getCanceledSspInquiryStatusSelector(): string {
     return this.repository.getCanceledSspInquiryStatusSelector();
   }
+
+  getCanceledSspInquiryStatus(): Cypress.Chainable {
+    return cy.get(this.repository.getCanceledSspInquiryStatusSelector());
+  }
 }
 
 export interface SspInquiryDetails {


### PR DESCRIPTION
## Summary

- Fixes all 41 `spryker-cypress/no-cy-get-outside-repository` violations across 10 spec files: customer-account-management (2), order-amendment-start (4), product-comparison (14), reorder (12 across 4 files), ssp-asset (5), ssp-inquiry (4).
- Bare `cy.contains(...)` / `cy.get('body').contains(...)` text assertions now go through the in-scope page object's `assertBodyContainsText` helper; raw `cy.get(page.getXSelector())` calls now go through new narrow wrapper methods on `ProductComparisonPage` (`getComparisonPageNavigationLink`, `getProductItems`, `getComparisonTableRow`) and `SspInquiryDetailPage` (`getCanceledSspInquiryStatus`).
- `AbstractPage.assertBodyContainsText` is added here as intentional duplication of sibling PR [#346](https://github.com/spryker/cypress-tests/pull/346) (not yet merged) — this branch was cut directly from `eslint-plugin-spryker-cypress` rather than stacked on #346, so the helper had to be added for this branch to lint/typecheck standalone. It's a one-line no-op collision once #346 merges.
- Covers the account/reorder/ssp half of the `yves/` domain backlog; a sibling PR (separate branch) covers checkout/catalog/cms/product/merchant-b2b-contract-requests.

## Test plan

- [x] `npm run lint` — zero `no-cy-get-outside-repository` violations remain in the 10 touched spec files, and no new violations of any other rule were introduced by this change.
- [x] `npm run typecheck` — passes.
- [ ] Live spec run against a Cypress-target docker stack — not possible this session (no available/matching stack; open follow-up item).