### PR TITLE
CC-39568 Add new repository selectors for remaining no-cy-get-outside-repository sites

### DIFF
--- a/cypress/e2e/backoffice/configuration/configuration-management.cy.ts
+++ b/cypress/e2e/backoffice/configuration/configuration-management.cy.ts
@@ -64,7 +64,7 @@ describe(
 
       configurationPage.searchSettings(staticFixtures.searchTerm);
 
-      cy.get('.js-nav-tab[data-tab="logos"]').should('be.visible');
+      configurationPage.getNavTab('logos').should('be.visible');
     });
 
     it('rejects an invalid hex color and keeps the original value', (): void => {

--- a/cypress/e2e/backoffice/configuration/configuration.cy.ts
+++ b/cypress/e2e/backoffice/configuration/configuration.cy.ts
@@ -1,6 +1,7 @@
 import { container } from '@utils';
 import { UserLoginScenario } from '@scenarios/backoffice';
 import { ConfigurationPage } from '@pages/backoffice';
+import { HomePage } from '@pages/yves';
 import { ConfigurationDynamicFixtures, ConfigurationStaticFixtures } from '@interfaces/backoffice';
 
 describe(
@@ -14,6 +15,7 @@ describe(
     };
 
     const configurationPage = container.get(ConfigurationPage);
+    const homePage = container.get(HomePage);
     const userLoginScenario = container.get(UserLoginScenario);
 
     let staticFixtures: ConfigurationStaticFixtures;
@@ -190,7 +192,7 @@ describe(
       cy.runQueueWorker();
 
       cy.visit('/');
-      cy.get('.logo img').should('have.attr', 'src').and('not.be.empty');
+      homePage.getLogoImage().should('have.attr', 'src').and('not.be.empty');
     });
 
     it('uploads backoffice logo and verifies it is applied in backoffice', (): void => {

--- a/cypress/e2e/backoffice/product-management/product-attachment-management.cy.ts
+++ b/cypress/e2e/backoffice/product-management/product-attachment-management.cy.ts
@@ -31,16 +31,12 @@ describe(
 
       productManagementEditPage.openMediaTab();
 
-      cy.contains('Product Attachments').should('be.visible');
-      cy.contains('Add URL-based attachments for different locales.').should('be.visible');
+      productManagementEditPage.getAttachmentsSectionHeading().should('be.visible');
+      productManagementEditPage.getAttachmentsSectionDescription().should('be.visible');
 
-      cy.get('.attachment-forms')
-        .first()
-        .within(() => {
-          cy.contains('.ibox-title', 'Default').should('be.visible');
-          cy.get('.ibox').first().should('not.have.class', 'collapsed');
-          cy.get('.add-another-attachment').first().should('be.visible');
-        });
+      productManagementEditPage.getFirstAttachmentFormLocaleTitle().should('be.visible');
+      productManagementEditPage.getFirstAttachmentFormIbox().should('not.have.class', 'collapsed');
+      productManagementEditPage.getFirstAttachmentFormAddButton().should('be.visible');
     });
 
     it('backoffice user can add and save single attachment to default locale', (): void => {

--- a/cypress/e2e/mp/marketplace-agent-assist/agent-impersonation.cy.ts
+++ b/cypress/e2e/mp/marketplace-agent-assist/agent-impersonation.cy.ts
@@ -54,21 +54,21 @@ describe(
 
     it('agent should be able to see merchant user information during impersonation', (): void => {
       mpDashboardPage.visit();
-      cy.get('body').find(`div:contains("${dynamicFixtures.merchant.name}")`).should('exist');
-      cy.get('body').find(`div:contains("${dynamicFixtures.merchantUser.username}")`).should('exist');
+      mpDashboardPage.getTextContainer(dynamicFixtures.merchant.name).should('exist');
+      mpDashboardPage.getTextContainer(dynamicFixtures.merchantUser.username).should('exist');
 
-      cy.get('body')
-        .find(`div:contains("${dynamicFixtures.merchantUser.first_name} ${dynamicFixtures.merchantUser.last_name}")`)
+      mpDashboardPage
+        .getTextContainer(`${dynamicFixtures.merchantUser.first_name} ${dynamicFixtures.merchantUser.last_name}`)
         .should('exist');
     });
 
     it('agent should be able to see agent assist buttons during impersonation', (): void => {
-      cy.get('body').find(mpAgentDashboardPage.getEndUserAssistanceSelector()).should('exist');
-      cy.get('body').find(mpAgentDashboardPage.getLogoutAgentSelector()).should('exist');
+      mpAgentDashboardPage.getEndUserAssistanceButton().should('exist');
+      mpAgentDashboardPage.getLogoutAgentButton().should('exist');
     });
 
     it('agent should be able to finish impersonation', (): void => {
-      cy.get('body').find(mpAgentDashboardPage.getEndUserAssistanceSelector()).click();
+      mpAgentDashboardPage.getEndUserAssistanceButton().click();
       mpAgentDashboardPage.assertPageLocation();
 
       // Ensure that agent finished assistant session and don't have access to MP dashboard
@@ -78,7 +78,7 @@ describe(
     });
 
     it('agent should be able to fully logout from all sessions', (): void => {
-      cy.get('body').find(mpAgentDashboardPage.getLogoutAgentSelector()).click();
+      mpAgentDashboardPage.getLogoutAgentButton().click();
       mpAgentLoginPage.assertPageLocation();
 
       mpAgentDashboardPage.visit();

--- a/cypress/e2e/mp/marketplace-agent-assist/agent-merchant-portal.cy.ts
+++ b/cypress/e2e/mp/marketplace-agent-assist/agent-merchant-portal.cy.ts
@@ -119,12 +119,13 @@ describe(
 
       productsPage.getDrawer().as('drawer');
 
-      cy.get('@drawer')
+      productsPage
+        .getDrawerAlias()
         .find(productsPage.getTaxIdSetOptionSelector())
         .eq(1)
-        .then((el) => cy.get(productsPage.getTaxIdSetSelector()).select(el.val() ?? '', { force: true }));
+        .then((el) => productsPage.selectTaxIdSetOption(el.val() ?? ''));
 
-      cy.get('@drawer').find(productsPage.getSaveButtonSelector()).click();
+      productsPage.getDrawerAlias().find(productsPage.getSaveButtonSelector()).click();
 
       cy.get('body').contains('The Product is saved.');
     });

--- a/cypress/e2e/smoke/ssp/ssp-model-create.cy.ts
+++ b/cypress/e2e/smoke/ssp/ssp-model-create.cy.ts
@@ -45,7 +45,8 @@ describe(
       sspModelAddPage.submitForm();
       sspModelAddPage.verifySuccessMessage();
 
-      cy.get('img[data-qa="ssp-model-image"]')
+      sspModelAddPage
+        .getModelImage()
         .should('be.visible')
         .and(($img) => {
           expect(

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,7 +10,8 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
-  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+  assertBodyContainsText = (text: string, options?: Partial<Cypress.Timeoutable>): Cypress.Chainable =>
+    cy.get('body').contains(text, options);
 
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/abstract-page.ts
+++ b/cypress/support/pages/abstract-page.ts
@@ -10,5 +10,7 @@ export class AbstractPage {
     cy.url({ timeout: 20000 }).should('include', this.PAGE_URL);
   };
 
+  assertBodyContainsText = (text: string): Cypress.Chainable => cy.get('body').contains(text);
+
   isRepository = (...ids: string[]): boolean => ids.includes(Cypress.env('repositoryId'));
 }

--- a/cypress/support/pages/backoffice/configuration/configuration-page.ts
+++ b/cypress/support/pages/backoffice/configuration/configuration-page.ts
@@ -153,6 +153,8 @@ export class ConfigurationPage extends BackofficePage {
     cy.get(this.repository.getNavTabSelector(tabKey)).click({ force: true });
   };
 
+  getNavTab = (tabKey: string): Cypress.Chainable => cy.get(this.repository.getNavTabSelector(tabKey));
+
   getSaveBar = (): Cypress.Chainable => cy.get(this.repository.getSaveBarSelector());
 
   getChangesCount = (): Cypress.Chainable => cy.get(this.repository.getChangesCountSelector());

--- a/cypress/support/pages/backoffice/product-management/edit/product-management-edit-page.ts
+++ b/cypress/support/pages/backoffice/product-management/edit/product-management-edit-page.ts
@@ -120,6 +120,16 @@ export class ProductManagementEditPage extends BackofficePage {
   };
 
   getMerchantNotAssignedOptionText = (): string => 'Not assigned';
+
+  getAttachmentsSectionHeading = (): Cypress.Chainable => this.repository.getAttachmentsSectionHeading();
+
+  getAttachmentsSectionDescription = (): Cypress.Chainable => this.repository.getAttachmentsSectionDescription();
+
+  getFirstAttachmentFormLocaleTitle = (): Cypress.Chainable => this.repository.getFirstAttachmentFormLocaleTitle();
+
+  getFirstAttachmentFormIbox = (): Cypress.Chainable => this.repository.getFirstAttachmentFormIbox();
+
+  getFirstAttachmentFormAddButton = (): Cypress.Chainable => this.repository.getFirstAttachmentFormAddButton();
 }
 
 interface AttachmentParams {

--- a/cypress/support/pages/backoffice/product-management/edit/product-management-edit-repository.ts
+++ b/cypress/support/pages/backoffice/product-management/edit/product-management-edit-repository.ts
@@ -66,6 +66,19 @@ export class ProductManagementEditRepository {
   getSaveSuccessMessage = (sku: string): Cypress.Chainable =>
     cy.contains(`The product [${sku}] was saved successfully`, { timeout: 10000 });
 
+  getAttachmentsSectionHeading = (): Cypress.Chainable => cy.contains('Product Attachments');
+
+  getAttachmentsSectionDescription = (): Cypress.Chainable =>
+    cy.contains('Add URL-based attachments for different locales.');
+
+  getFirstAttachmentFormLocaleTitle = (): Cypress.Chainable =>
+    cy.get('.attachment-forms').first().contains('.ibox-title', 'Default');
+
+  getFirstAttachmentFormIbox = (): Cypress.Chainable => cy.get('.attachment-forms').first().find('.ibox').first();
+
+  getFirstAttachmentFormAddButton = (): Cypress.Chainable =>
+    cy.get('.attachment-forms').first().find('.add-another-attachment').first();
+
   private getAttachmentLocaleContainer = (locale: string): Cypress.Chainable =>
     cy.get('.attachment-forms').contains('.ibox-title', this.getLocaleDisplayName(locale)).closest('.ibox');
 

--- a/cypress/support/pages/backoffice/ssp-model-management/add/ssp-model-add-page.ts
+++ b/cypress/support/pages/backoffice/ssp-model-management/add/ssp-model-add-page.ts
@@ -31,4 +31,8 @@ export class SspModelAddPage extends BackofficePage {
     this.repository.getSuccessMessageContainer().should('be.visible');
     cy.contains(this.repository.getSuccessMessage()).should('be.visible');
   }
+
+  public getModelImage(): Cypress.Chainable {
+    return this.repository.getModelImage();
+  }
 }

--- a/cypress/support/pages/backoffice/ssp-model-management/add/ssp-model-add-repository.ts
+++ b/cypress/support/pages/backoffice/ssp-model-management/add/ssp-model-add-repository.ts
@@ -10,4 +10,5 @@ export class SspModelAddRepository {
   getSubmitButton = (): Cypress.Chainable => cy.get('form[name="modelForm"] button[data-qa="submit"]');
   getSuccessMessageContainer = (): Cypress.Chainable => cy.get('[data-qa*="success-message"]');
   getSuccessMessage = (): string => 'Model has been successfully created';
+  getModelImage = (): Cypress.Chainable => cy.get('img[data-qa="ssp-model-image"]');
 }

--- a/cypress/support/pages/mp/agent-dashboard/agent-dashboard-page.ts
+++ b/cypress/support/pages/mp/agent-dashboard/agent-dashboard-page.ts
@@ -100,6 +100,14 @@ export class AgentDashboardPage extends MpPage {
     return this.repository.getLogoutAgentSelector();
   };
 
+  getEndUserAssistanceButton = (): Cypress.Chainable => {
+    return cy.get('body').find(this.repository.getEndUserAssistanceSelector());
+  };
+
+  getLogoutAgentButton = (): Cypress.Chainable => {
+    return cy.get('body').find(this.repository.getLogoutAgentSelector());
+  };
+
   logoutAgent = (): void => {
     this.repository.getUserMenu().click();
     cy.contains('a', 'Logout').click({ force: true });

--- a/cypress/support/pages/mp/dashboard/dashboard-page.ts
+++ b/cypress/support/pages/mp/dashboard/dashboard-page.ts
@@ -30,6 +30,9 @@ export class DashboardPage extends MpPage {
       }
     });
   };
+
+  getTextContainer = (text: string): Cypress.Chainable =>
+    cy.get('body').find(this.repository.getTextContainerSelector(text));
 }
 
 interface Assert500StatusCodeParams {

--- a/cypress/support/pages/mp/dashboard/dashboard-repository.ts
+++ b/cypress/support/pages/mp/dashboard/dashboard-repository.ts
@@ -7,4 +7,5 @@ export class DashboardRepository {
   getUserProfileMenu = (): Cypress.Chainable => cy.get('.spy-user-menu');
   getLogoutButton = (): Cypress.Chainable =>
     cy.get('.spy-user-menu__content.ng-star-inserted').find('a:contains("Logout")');
+  getTextContainerSelector = (text: string): string => `div:contains("${text}")`;
 }

--- a/cypress/support/pages/mp/products/products-page.ts
+++ b/cypress/support/pages/mp/products/products-page.ts
@@ -76,6 +76,11 @@ export class ProductsPage extends MpPage {
   getTaxIdSetOptionSelector = (): string => {
     return this.repository.getTaxIdOptionSelector();
   };
+
+  getDrawerAlias = (): Cypress.Chainable => cy.get('@drawer');
+
+  selectTaxIdSetOption = (value: string | number | string[]): Cypress.Chainable =>
+    cy.get(this.repository.getTaxIdSelector()).select(value, { force: true });
 }
 
 interface FindParams {

--- a/cypress/support/pages/yves/home/home-page.ts
+++ b/cypress/support/pages/yves/home/home-page.ts
@@ -43,4 +43,8 @@ export class HomePage extends YvesPage {
   getLogo(): Cypress.Chainable {
     return this.repository.getLogo();
   }
+
+  getLogoImage(): Cypress.Chainable {
+    return this.repository.getLogoImage();
+  }
 }

--- a/cypress/support/pages/yves/home/home-repository.ts
+++ b/cypress/support/pages/yves/home/home-repository.ts
@@ -5,4 +5,5 @@ export interface HomeRepository {
   getNavigationNewLink(newPageLinkText: string): Cypress.Chainable;
   getLanguageSwitcher(): Cypress.Chainable;
   getLogo(): Cypress.Chainable;
+  getLogoImage(): Cypress.Chainable;
 }

--- a/cypress/support/pages/yves/home/repositories/b2b-home-repository.ts
+++ b/cypress/support/pages/yves/home/repositories/b2b-home-repository.ts
@@ -22,4 +22,7 @@ export class B2bHomeRepository implements HomeRepository {
   getLogo = (): Cypress.Chainable => {
     return cy.get('[data-qa="component logo"]');
   };
+  getLogoImage = (): Cypress.Chainable => {
+    return cy.get('.logo img');
+  };
 }

--- a/cypress/support/pages/yves/home/repositories/b2b-mp-home-repository.ts
+++ b/cypress/support/pages/yves/home/repositories/b2b-mp-home-repository.ts
@@ -22,4 +22,7 @@ export class B2bMpHomeRepository implements HomeRepository {
   getLogo = (): Cypress.Chainable => {
     return cy.get('[data-qa="component logo"]');
   };
+  getLogoImage = (): Cypress.Chainable => {
+    return cy.get('.logo img');
+  };
 }

--- a/cypress/support/pages/yves/home/repositories/b2c-home-repository.ts
+++ b/cypress/support/pages/yves/home/repositories/b2c-home-repository.ts
@@ -22,4 +22,7 @@ export class B2cHomeRepository implements HomeRepository {
   getLogo = (): Cypress.Chainable => {
     return cy.get('[data-qa="component logo"]');
   };
+  getLogoImage = (): Cypress.Chainable => {
+    return cy.get('.logo img');
+  };
 }

--- a/cypress/support/pages/yves/home/repositories/b2c-mp-home-repository.ts
+++ b/cypress/support/pages/yves/home/repositories/b2c-mp-home-repository.ts
@@ -22,4 +22,7 @@ export class B2cMpHomeRepository implements HomeRepository {
   getLogo = (): Cypress.Chainable => {
     return cy.get('[data-qa="component logo"]');
   };
+  getLogoImage = (): Cypress.Chainable => {
+    return cy.get('.logo img');
+  };
 }

--- a/cypress/support/pages/yves/home/repositories/suite-home-repository.ts
+++ b/cypress/support/pages/yves/home/repositories/suite-home-repository.ts
@@ -22,4 +22,7 @@ export class SuiteHomeRepository implements HomeRepository {
   getLogo = (): Cypress.Chainable => {
     return cy.get('[data-qa="component logo"]');
   };
+  getLogoImage = (): Cypress.Chainable => {
+    return cy.get('.logo img');
+  };
 }


### PR DESCRIPTION
## Summary

Fixes 18 of the 19 hardest leftover `no-cy-get-outside-repository` sites — the ones needing new selectors/page-object methods rather than mechanical relocation of an existing one. 1 site was already covered by a change that landed on another branch and needed no further work here (see below).

Also duplicates `AbstractPage.assertBodyContainsText` from sibling PR #346, since this branch was cut directly from `eslint-plugin-spryker-cypress` (not stacked on #346) and needs to lint/typecheck standalone.

**This batch adds genuinely new selectors** (not just relocating existing ones), so it's the highest-risk slice of the whole cleanup — runtime verification matters more than usual here.

### Fixed (18 sites)

- `cypress/e2e/backoffice/configuration/configuration.cy.ts:193` — storefront logo `<img>` assertion moved to a new `HomePage.getLogoImage()` (yves), backed by a new `getLogoImage()` on the `HomeRepository` interface and all 5 concrete implementations (Suite/B2B/B2B-MP/B2C/B2C-MP — identical literal `.logo img` across stores).
- `cypress/e2e/backoffice/configuration/configuration-management.cy.ts:67` — nav-tab visibility now uses a new `ConfigurationPage.getNavTab()`, reusing the existing `getNavTabSelector()` repository getter.
- `cypress/e2e/backoffice/product-management/product-attachment-management.cy.ts:34,35,37,40,41,42` (6 sites) — new `ProductManagementEditPage`/`ProductManagementEditRepository` getters for the attachments section heading, description, first-locale title, ibox, and add-button.
- `cypress/e2e/mp/marketplace-agent-assist/agent-impersonation.cy.ts:57,58,60,66,67,71,81` (7 sites) — new `DashboardPage.getTextContainer(text)` (parameterized `div:contains()` lookup) for the dynamic-fixture assertions, and new `AgentDashboardPage.getEndUserAssistanceButton()`/`getLogoutAgentButton()` wrapping the already-existing repository selector getters.
- `cypress/e2e/smoke/ssp/ssp-model-create.cy.ts:48` — new `SspModelAddPage.getModelImage()` / repository `getModelImage()`.
- `cypress/e2e/mp/marketplace-agent-assist/agent-merchant-portal.cy.ts:122,125,127` — new `ProductsPage.getDrawerAlias()` (wraps the `@drawer` Cypress alias, kept in the page object since it isn't a DOM selector) and `ProductsPage.selectTaxIdSetOption()`.

### Deferred (0 sites)

None — all 19 assigned sites were resolved; one (`agent-merchant-portal.cy.ts:129`) was explicitly out of scope, already fixed on a different branch, and left untouched here.

### Out of scope, untouched by design

`agent-merchant-portal.cy.ts:107,143` and the now-shifted `:130,:144` (was `:129,:143`) are being handled by sibling PRs — not touched here.

## Test plan

- [x] `npm run lint` — the 6 touched spec files show 0 `no-cy-get-outside-repository` warnings for the sites listed above (the 3 out-of-scope lines in `agent-merchant-portal.cy.ts` still correctly show, untouched); no new violations of `no-assertions-in-page-objects` or any other rule introduced.
- [x] `npm run typecheck` — passes clean.
- [x] `npx prettier --check` on all touched files — passes.
- [ ] **Spec run against a live Cypress target — NOT DONE.** No compatible docker stack was available this session (only an unrelated env and another engineer's active worktree stack were up, neither touched). This is an open follow-up and the main risk on this PR: several selectors here are genuinely new (yves logo image, ssp model image, mp dashboard text-contains, product-attachment media panel) rather than relocated from working code, so they haven't been runtime-verified. Please run the affected specs against a live stack before merging past draft.