### PR TITLE
CC-39441 Quarantine order-amendment-start.cy.ts pending fix

### DIFF
--- a/cypress/e2e/yves/order-amendment/order-amendment-start.cy.ts
+++ b/cypress/e2e/yves/order-amendment/order-amendment-start.cy.ts
@@ -15,6 +15,7 @@ describe(
     tags: [
       '@yves',
       '@order-amendment',
+      '@quarantine',
       'product',
       'marketplace-product',
       'marketplace-merchant-portal-product-management',


### PR DESCRIPTION
## Summary
- Tags `order amendment start` with `@quarantine` so it's excluded from the blocking Cypress shards and picked up by the new non-blocking `cypress-quarantine` lane instead (spryker/suite#882).
- Recurring flake: fails on first run, passes clean on the fresh-browser rerun.

Jira: https://spryker.atlassian.net/browse/CC-39441

## Test plan
- [ ] Paired with spryker/suite#882 (which pins this branch temporarily) to confirm `cypress-quarantine-detect` flips to true and `cypress-quarantine` runs this spec non-blocking.
- [ ] Confirm the blocking Cypress shards no longer execute this spec.