### PR TITLE
CC-38848 Drain publish queue while waiting for deleted attachments to clear

### DIFF
--- a/cypress/e2e/yves/product/product-attachment-storefront.cy.ts
+++ b/cypress/e2e/yves/product/product-attachment-storefront.cy.ts
@@ -185,12 +185,17 @@ describe(
       cy.runQueueWorker();
 
       // Assert
-      // The delete's publish->sync can land after the single PDP load, so a one-shot
-      // not.exist "continuously found" the still-rendered list and failed every retry.
-      // Reload the PDP until the attachment list has actually dropped out of storage.
+      // The delete's publish->sync is a multi-stage queue chain, so a single runQueueWorker
+      // pass can finish before the sync message removes the attachment from storage. Keep
+      // draining the queue on every reload until the attachment list has actually dropped
+      // out of storage, otherwise the loop polls a page backed by a queue nothing is
+      // processing and never converges.
       visitProductDetailPage();
       cy.url().then((url) => {
-        cy.reloadUntilGone(url, productPage.getAttachmentsListSelector());
+        cy.reloadUntilGone(url, productPage.getAttachmentsListSelector(), 'body', 25, 5000, [
+          'console queue:worker:start --stop-when-empty',
+          'console queue:worker:start --stop-when-empty',
+        ]);
       });
       productPage.getAttachmentsList().should('not.exist');
     });

--- a/cypress/e2e/yves/product/product-attachment-storefront.cy.ts
+++ b/cypress/e2e/yves/product/product-attachment-storefront.cy.ts
@@ -185,15 +185,11 @@ describe(
       cy.runQueueWorker();
 
       // Assert
-      // The delete's publish->sync is a multi-stage queue chain, so a single runQueueWorker
-      // pass can finish before the sync message removes the attachment from storage. Keep
-      // draining the queue on every reload until the attachment list has actually dropped
-      // out of storage, otherwise the loop polls a page backed by a queue nothing is
-      // processing and never converges.
+      // The delete's publish->sync can still be draining after the single worker run above,
+      // so re-drain the queue on every reload until the attachment list clears from storage.
       visitProductDetailPage();
       cy.url().then((url) => {
         cy.reloadUntilGone(url, productPage.getAttachmentsListSelector(), 'body', 25, 5000, [
-          'console queue:worker:start --stop-when-empty',
           'console queue:worker:start --stop-when-empty',
         ]);
       });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -121,12 +121,9 @@ Cypress.Commands.add(
 );
 
 // Inverse of reloadUntilFound: re-visits the page until findSelector is ABSENT.
-// Needed on the storefront delete path, where publish->sync can lag a single PDP
-// load and cy.get().should('not.exist') then keeps finding the still-rendered node.
-// `commands` are re-run before every reload so the publish/sync queue keeps draining
-// while we wait: without it the loop polls a page backed by a multi-stage queue that
-// nothing is processing between reloads, so a lagging sync message never lands and the
-// list never disappears (exhausted retries), even though the delete itself succeeded.
+// `commands` (if given) are re-run before every reload so a lagging publish/sync queue
+// keeps draining while we wait; otherwise a delete that hasn't finished syncing keeps
+// rendering the node and the loop never converges (exhausted retries).
 Cypress.Commands.add(
   'reloadUntilGone',
   (url, findSelector, getSelector = 'body', retries = 25, retryWait = 5000, commands = []) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -123,24 +123,35 @@ Cypress.Commands.add(
 // Inverse of reloadUntilFound: re-visits the page until findSelector is ABSENT.
 // Needed on the storefront delete path, where publish->sync can lag a single PDP
 // load and cy.get().should('not.exist') then keeps finding the still-rendered node.
-Cypress.Commands.add('reloadUntilGone', (url, findSelector, getSelector = 'body', retries = 25, retryWait = 5000) => {
-  if (retries === 0) {
-    throw `exhausted retries waiting for ${findSelector} to disappear on ${url}`;
-  }
-
-  cy.visit(url);
-  cy.get(getSelector).then((body) => {
-    const msg = `url:${url} getSelector:${getSelector} findSelector:${findSelector} retries:${retries} retryWait:${retryWait}`;
-
-    if (body.find(findSelector).length === 0) {
-      cy.log(`gone ${msg}`);
-    } else {
-      cy.log(`still present ${msg}`);
-      cy.wait(retryWait);
-      cy.reloadUntilGone(url, findSelector, getSelector, retries - 1, retryWait);
+// `commands` are re-run before every reload so the publish/sync queue keeps draining
+// while we wait: without it the loop polls a page backed by a multi-stage queue that
+// nothing is processing between reloads, so a lagging sync message never lands and the
+// list never disappears (exhausted retries), even though the delete itself succeeded.
+Cypress.Commands.add(
+  'reloadUntilGone',
+  (url, findSelector, getSelector = 'body', retries = 25, retryWait = 5000, commands = []) => {
+    if (retries === 0) {
+      throw `exhausted retries waiting for ${findSelector} to disappear on ${url}`;
     }
-  });
-});
+
+    if (commands.length) {
+      cy.runCliCommands(commands);
+    }
+
+    cy.visit(url);
+    cy.get(getSelector).then((body) => {
+      const msg = `url:${url} getSelector:${getSelector} findSelector:${findSelector} retries:${retries} retryWait:${retryWait}`;
+
+      if (body.find(findSelector).length === 0) {
+        cy.log(`gone ${msg}`);
+      } else {
+        cy.log(`still present ${msg}`);
+        cy.wait(retryWait);
+        cy.reloadUntilGone(url, findSelector, getSelector, retries - 1, retryWait, commands);
+      }
+    });
+  }
+);
 
 Cypress.Commands.add('runCliCommands', (commands) => {
   const operations = commands.map((command) => {

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -61,7 +61,8 @@ declare namespace Cypress {
       findSelector: string,
       getSelector?: string,
       retries?: number,
-      retryWait?: number
+      retryWait?: number,
+      commands?: string[]
     ): void;
 
     /**


### PR DESCRIPTION
## Summary
`product-attachment-storefront.cy.ts` "…cannot see attachments after they are deleted in backoffice" flakes run-to-run on master compat CI. Root cause is test-infra, not product code: the delete's publish→sync is a multi-stage queue chain, and `reloadUntilGone` reloaded the PDP but never re-drained the queue between reloads (unlike `reloadUntilFound`), so a lagging sync message never landed and the list never disappeared ("exhausted retries").

Fix: `reloadUntilGone` now takes a `commands` arg (mirroring `reloadUntilFound`) and re-runs the queue worker on every reload, so the wait keeps draining until storage actually reflects the delete.

Jira: https://spryker.atlassian.net/browse/CC-38848

## Test plan
- `tsc --noEmit` + Prettier green locally.
- Cypress CI on this branch: the attachment-storefront spec passes without exhausting retries.