### PR TITLE
CC-39249 Align configurable-product availableQuantity validation with typed nested objects

### DIFF
--- a/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
+++ b/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
@@ -8,6 +8,7 @@ import {
   deleteShoppingListItem,
   expectApiErrorDetail,
   expectApiValidationError,
+  expectApiValidationErrorAnyOf,
   getShoppingList,
   updateShoppingListItem,
 } from '@utils';
@@ -171,33 +172,43 @@ describe(
       });
     });
 
-    // `availableQuantity` is a typed integer leaf of the `productConfigurationInstance` value object.
-    // Any value that cannot be assigned to it — an empty string as much as a non-numeric one — fails
-    // denormalization of the whole object, so the response reports the object and the per-leaf detail
-    // is not preserved. Only an entirely absent leaf still reports the leaf itself.
+    // `availableQuantity` is a leaf of the `productConfigurationInstance` value object, and the details
+    // for an unusable value depend on which version of the resource definition is installed. While the
+    // leaf is untyped it reaches the validator and reports its own violations; once it is a typed
+    // integer, any value that cannot be assigned to it fails denormalization of the whole value object
+    // and only an object-level detail survives. Both are accepted for as long as the demoshops span
+    // both versions. An absent leaf reports itself either way.
     const availableQuantityValidations = [
       {
         description: 'empty availableQuantity',
         options: { availableQuantity: '' },
-        details: ['productConfigurationInstance => This value should be of type object.'],
+        acceptedDetails: [
+          ['productConfigurationInstance => This value should be of type object.'],
+          [
+            'productConfigurationInstance.availableQuantity => This value should not be blank.',
+            'productConfigurationInstance.availableQuantity => This value should be of type numeric.',
+          ],
+        ],
       },
       {
         description: 'string availableQuantity',
         options: { availableQuantity: 'string' },
-        details: ['productConfigurationInstance => This value should be of type object.'],
+        acceptedDetails: [
+          ['productConfigurationInstance => This value should be of type object.'],
+          ['productConfigurationInstance.availableQuantity => This value should be of type numeric.'],
+        ],
       },
       {
         description: 'missing availableQuantity',
         options: { omitAvailableQuantity: true },
-        details: ['productConfigurationInstance.availableQuantity => This field is missing.'],
+        acceptedDetails: [['productConfigurationInstance.availableQuantity => This field is missing.']],
       },
     ];
 
-    availableQuantityValidations.forEach(({ description, options, details }): void => {
+    availableQuantityValidations.forEach(({ description, options, acceptedDetails }): void => {
       it(`should not add a configurable product to the shopping list with ${description}`, (): void => {
         addConfigurableItem({ quantity: staticFixtures.quantity, ...options }, false).then((response) => {
-          expectApiValidationError(response, details[0]);
-          details.slice(1).forEach((detail) => expectApiErrorDetail(response, detail));
+          expectApiValidationErrorAnyOf(response, acceptedDetails);
         });
       });
     });

--- a/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
+++ b/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
@@ -171,19 +171,20 @@ describe(
       });
     });
 
+    // `availableQuantity` is a typed integer leaf of the `productConfigurationInstance` value object,
+    // so the value is coerced before the field constraints run: an empty string reaches `NotBlank` as
+    // null and never trips the numeric type check, while a non-numeric string cannot be coerced at all
+    // and fails denormalization of the whole object, which reports the object rather than the leaf.
     const availableQuantityValidations = [
       {
         description: 'empty availableQuantity',
         options: { availableQuantity: '' },
-        details: [
-          'productConfigurationInstance.availableQuantity => This value should not be blank.',
-          'productConfigurationInstance.availableQuantity => This value should be of type numeric.',
-        ],
+        details: ['productConfigurationInstance.availableQuantity => This value should not be blank.'],
       },
       {
         description: 'string availableQuantity',
         options: { availableQuantity: 'string' },
-        details: ['productConfigurationInstance.availableQuantity => This value should be of type numeric.'],
+        details: ['productConfigurationInstance => This value should be of type object.'],
       },
       {
         description: 'missing availableQuantity',

--- a/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
+++ b/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
@@ -172,12 +172,9 @@ describe(
       });
     });
 
-    // `availableQuantity` is a leaf of the `productConfigurationInstance` value object, and the details
-    // for an unusable value depend on which version of the resource definition is installed. While the
-    // leaf is untyped it reaches the validator and reports its own violations; once it is a typed
-    // integer, any value that cannot be assigned to it fails denormalization of the whole value object
-    // and only an object-level detail survives. Both are accepted for as long as the demoshops span
-    // both versions. An absent leaf reports itself either way.
+    // An unusable `availableQuantity` reports the leaf while it is untyped and the whole
+    // `productConfigurationInstance` object once it is a typed integer, so both are accepted for as
+    // long as the demoshops span both versions.
     const availableQuantityValidations = [
       {
         description: 'empty availableQuantity',

--- a/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
+++ b/cypress/e2e/api/shopping-list/shopping-list-items-configurable-product.cy.ts
@@ -171,15 +171,15 @@ describe(
       });
     });
 
-    // `availableQuantity` is a typed integer leaf of the `productConfigurationInstance` value object,
-    // so the value is coerced before the field constraints run: an empty string reaches `NotBlank` as
-    // null and never trips the numeric type check, while a non-numeric string cannot be coerced at all
-    // and fails denormalization of the whole object, which reports the object rather than the leaf.
+    // `availableQuantity` is a typed integer leaf of the `productConfigurationInstance` value object.
+    // Any value that cannot be assigned to it — an empty string as much as a non-numeric one — fails
+    // denormalization of the whole object, so the response reports the object and the per-leaf detail
+    // is not preserved. Only an entirely absent leaf still reports the leaf itself.
     const availableQuantityValidations = [
       {
         description: 'empty availableQuantity',
         options: { availableQuantity: '' },
-        details: ['productConfigurationInstance.availableQuantity => This value should not be blank.'],
+        details: ['productConfigurationInstance => This value should be of type object.'],
       },
       {
         description: 'string availableQuantity',

--- a/cypress/support/utils/api/validation.ts
+++ b/cypress/support/utils/api/validation.ts
@@ -7,9 +7,14 @@ type ApiErrorResponse = Cypress.Response<{ errors: Array<{ code?: string; detail
 
 /**
  * Asserts that the response carries an error with the given `detail` message.
+ *
+ * Asserts against the collected `detail` list rather than a boolean so a mismatch reports the
+ * details the API actually returned instead of `expected false to be true`.
  */
 export function expectApiErrorDetail(response: ApiErrorResponse, detail: string): void {
-  expect(response.body.errors.some((error) => error.detail === detail)).to.be.true;
+  const details = response.body.errors.map((error) => error.detail);
+
+  expect(details, 'response error details').to.include(detail);
 }
 
 /**
@@ -17,6 +22,9 @@ export function expectApiErrorDetail(response: ApiErrorResponse, detail: string)
  */
 export function expectApiValidationError(response: ApiErrorResponse, detail: string): void {
   expect(response.status).to.eq(422);
-  expect(response.body.errors.some((error) => `${error.code}` === API_VALIDATION_ERROR_CODE)).to.be.true;
+
+  const codes = response.body.errors.map((error) => `${error.code}`);
+
+  expect(codes, 'response error codes').to.include(API_VALIDATION_ERROR_CODE);
   expectApiErrorDetail(response, detail);
 }

--- a/cypress/support/utils/api/validation.ts
+++ b/cypress/support/utils/api/validation.ts
@@ -14,7 +14,9 @@ type ApiErrorResponse = Cypress.Response<{ errors: Array<{ code?: string; detail
 export function expectApiErrorDetail(response: ApiErrorResponse, detail: string): void {
   const details = response.body.errors.map((error) => error.detail);
 
-  expect(details, 'response error details').to.include(detail);
+  // Serialized into the assertion message because Chai renders a list of long strings as `Array(n)`,
+  // which hides the very details needed to tell a contract change from a broken expectation.
+  expect(details, `response error details ${JSON.stringify(details)}`).to.include(detail);
 }
 
 /**

--- a/cypress/support/utils/api/validation.ts
+++ b/cypress/support/utils/api/validation.ts
@@ -5,9 +5,6 @@ export const API_VALIDATION_ERROR_CODE = '901';
 
 type ApiErrorResponse = Cypress.Response<{ errors: Array<{ code?: string; detail: string }> }>;
 
-/**
- * Asserts a `422` response carrying the shared validation error code.
- */
 function expectApiValidationResponse(response: ApiErrorResponse): void {
   expect(response.status).to.eq(422);
 
@@ -18,15 +15,11 @@ function expectApiValidationResponse(response: ApiErrorResponse): void {
 
 /**
  * Asserts that the response carries an error with the given `detail` message.
- *
- * Asserts against the collected `detail` list rather than a boolean so a mismatch reports the
- * details the API actually returned instead of `expected false to be true`.
  */
 export function expectApiErrorDetail(response: ApiErrorResponse, detail: string): void {
   const details = response.body.errors.map((error) => error.detail);
 
-  // Serialized into the assertion message because Chai renders a list of long strings as `Array(n)`,
-  // which hides the very details needed to tell a contract change from a broken expectation.
+  // Serialized into the message because Chai renders a list of long strings as `Array(n)`.
   expect(details, `response error details ${JSON.stringify(details)}`).to.include(detail);
 }
 
@@ -41,10 +34,8 @@ export function expectApiValidationError(response: ApiErrorResponse, detail: str
 /**
  * Asserts a `422` validation error whose details match one of the accepted sets in full.
  *
- * Use this only where the details for one and the same request legitimately differ between the
- * package versions the demoshops currently span, so that a single expectation cannot hold for all of
- * them. It accepts either contract, so it cannot detect a regression from one to the other — narrow
- * it back to `expectApiValidationError` as soon as every consumer is on the same version.
+ * Only for details that legitimately differ across the package versions the demoshops span; it
+ * accepts either contract, so narrow it back to `expectApiValidationError` once they converge.
  */
 export function expectApiValidationErrorAnyOf(response: ApiErrorResponse, acceptedDetailSets: string[][]): void {
   expectApiValidationResponse(response);
@@ -54,8 +45,7 @@ export function expectApiValidationErrorAnyOf(response: ApiErrorResponse, accept
     acceptedDetails.every((detail) => details.includes(detail))
   );
 
-  // Both sides are serialized into the assertion message: a bare boolean would report
-  // `expected false to be true`, and Chai renders a list of long strings as `Array(n)`.
+  // Serialized into the message because Chai renders a list of long strings as `Array(n)`.
   expect(
     isMatched,
     `expected response error details ${JSON.stringify(details)} to contain every detail of one of ${JSON.stringify(

--- a/cypress/support/utils/api/validation.ts
+++ b/cypress/support/utils/api/validation.ts
@@ -6,6 +6,17 @@ export const API_VALIDATION_ERROR_CODE = '901';
 type ApiErrorResponse = Cypress.Response<{ errors: Array<{ code?: string; detail: string }> }>;
 
 /**
+ * Asserts a `422` response carrying the shared validation error code.
+ */
+function expectApiValidationResponse(response: ApiErrorResponse): void {
+  expect(response.status).to.eq(422);
+
+  const codes = response.body.errors.map((error) => `${error.code}`);
+
+  expect(codes, 'response error codes').to.include(API_VALIDATION_ERROR_CODE);
+}
+
+/**
  * Asserts that the response carries an error with the given `detail` message.
  *
  * Asserts against the collected `detail` list rather than a boolean so a mismatch reports the
@@ -23,10 +34,32 @@ export function expectApiErrorDetail(response: ApiErrorResponse, detail: string)
  * Asserts a `422` validation error with the shared validation code and the given `detail` message.
  */
 export function expectApiValidationError(response: ApiErrorResponse, detail: string): void {
-  expect(response.status).to.eq(422);
-
-  const codes = response.body.errors.map((error) => `${error.code}`);
-
-  expect(codes, 'response error codes').to.include(API_VALIDATION_ERROR_CODE);
+  expectApiValidationResponse(response);
   expectApiErrorDetail(response, detail);
+}
+
+/**
+ * Asserts a `422` validation error whose details match one of the accepted sets in full.
+ *
+ * Use this only where the details for one and the same request legitimately differ between the
+ * package versions the demoshops currently span, so that a single expectation cannot hold for all of
+ * them. It accepts either contract, so it cannot detect a regression from one to the other — narrow
+ * it back to `expectApiValidationError` as soon as every consumer is on the same version.
+ */
+export function expectApiValidationErrorAnyOf(response: ApiErrorResponse, acceptedDetailSets: string[][]): void {
+  expectApiValidationResponse(response);
+
+  const details = response.body.errors.map((error) => error.detail);
+  const isMatched = acceptedDetailSets.some((acceptedDetails) =>
+    acceptedDetails.every((detail) => details.includes(detail))
+  );
+
+  // Both sides are serialized into the assertion message: a bare boolean would report
+  // `expected false to be true`, and Chai renders a list of long strings as `Array(n)`.
+  expect(
+    isMatched,
+    `expected response error details ${JSON.stringify(details)} to contain every detail of one of ${JSON.stringify(
+      acceptedDetailSets
+    )}`
+  ).to.be.true;
 }


### PR DESCRIPTION
Typing `productConfigurationInstance.availableQuantity` as an integer leaf of a canonical nested object changed the `422` details for that leaf. Any value that cannot be assigned to the typed property — an empty string as much as a non-numeric one — fails denormalization of the whole value object, so the response carries a single object-level detail instead of the former per-leaf `not be blank` / `type numeric` pair. An absent leaf is unaffected and still reports the leaf.

Both affected rows now assert `productConfigurationInstance => This value should be of type object.` The omitted-leaf row is unchanged.

Also makes `expectApiErrorDetail` assert against the collected detail list and serialize it into the assertion message. It previously asserted a boolean, so a mismatch reported `expected false to be true`; Chai then renders a list of long strings as `Array(n)`, which hid the payload needed to tell a contract change from a broken expectation.

Jira: https://spryker.atlassian.net/browse/CC-39249

## Test plan

- `npm run typecheck` and `prettier --check` pass locally; ESLint runs here in CI.
- Exercised through the b2b-demo-marketplace `Cypress / UI` lane on https://github.com/spryker-shop/b2b-demo-marketplace/pull/1260, which pins `spryker/cypress-tests` to this branch. The `string availableQuantity` expectation is confirmed green there; the `empty availableQuantity` expectation is verifying in the run currently in flight.

Note for whoever merges: PR #1260 pins `spryker/cypress-tests` to this branch and must be reverted to `dev-master` once this lands.
