### PR TITLE
CC-39284 Verify the store relation tables were actually selected

### DIFF
--- a/cypress/support/pages/backoffice/store/create/store-create-page.ts
+++ b/cypress/support/pages/backoffice/store/create/store-create-page.ts
@@ -18,20 +18,20 @@ export class StoreCreatePage extends BackofficePage {
     this.repository.getDefaultLocaleSelect().select(store.locale, { force: true });
     this.repository.getLocaleSearchInput().clear().type(store.locale, { delay: 0 });
     this.interceptTable({ url: '/locale-gui/index/available-locale-table-selectable**' }).then(() => {
-      this.repository.getAvailableLocaleInput(store.locale).click({ force: true });
+      this.checkRelation(this.repository.getAvailableLocaleInput(store.locale));
     });
 
     this.repository.getCurrenciesTab().click();
     this.repository.getDefaultCurrencySelect().select(store.currency, { force: true });
     this.repository.getCurrencySearchInput().clear().type(store.currency);
     this.interceptTable({ url: '/currency-gui/index/available-currency-table-selectable**' }).then(() => {
-      this.repository.getAvailableCurrencyInput(store.currency).click({ force: true });
+      this.checkRelation(this.repository.getAvailableCurrencyInput(store.currency));
     });
 
     this.repository.getDisplayRegionsTab().click();
     this.repository.getCountrySearchInput().clear().type(store.country);
     this.interceptTable({ url: '/country-gui/index/available-country-table-selectable**' }).then(() => {
-      this.repository.getAvailableCountryInput(store.country).click({ force: true });
+      this.checkRelation(this.repository.getAvailableCountryInput(store.country));
     });
 
     this.repository.getStoreContextTabButton().click();
@@ -39,6 +39,17 @@ export class StoreCreatePage extends BackofficePage {
     this.repository.getTimezoneSelector().select(store.timezone);
 
     this.repository.getSaveButton().click();
+  };
+
+  // The relation tables redraw after their selectable-table request resolves, so a bare
+  // click can land on a row that is about to be replaced. `force: true` then hides the
+  // failure and the store saves without that relation — a store with no locale is
+  // accepted, published into the store list, and only surfaces much later as a 500 from
+  // Yves when something visits it (`defaultLocaleIsoCode` is null). `check()` is
+  // checkbox-aware and idempotent, and the retried assertion makes a lost click fail
+  // here, where the cause is obvious, instead of in an unrelated hook.
+  private checkRelation = (input: Cypress.Chainable): void => {
+    input.check({ force: true }).should('be.checked');
   };
 }
 


### PR DESCRIPTION
The locale, currency and display-region tables in the Backoffice store-create form redraw after their selectable-table request resolves, so a bare `click()` can land on a row that is about to be replaced. `force: true` then suppresses the failure and the store saves without that relation.

A store with no locale is accepted, and it still gets published into the store list — so Yves routes to it and throws `NullValueException` on `defaultLocaleIsoCode`. The result is a 500 that surfaces much later, in whichever spec visits the store first, with nothing pointing back at store creation.

`check()` is checkbox-aware and idempotent (all three tables render `<input type="checkbox" value="…">`), and the retried `should('be.checked')` makes a lost click fail at creation time instead.

https://spryker.atlassian.net/browse/CC-39284

## Test plan

- Found on a sharded demoshop CI run: the store row existed, `spy_locale_store` had **no rows** for it, `spy_store_storage` had **no row** for it, and `kv:store_list` advertised it anyway. All queues were empty, so it was not a publish or sync delay — the source data was incomplete.
- `npm run typecheck`, `npm run lint` and `prettier --check` all clean.
- Cannot regress a run where the click already lands: `check()` is a no-op on an already-checked box and the assertion passes immediately.
- Needs cherry-picking to `release_202512.0_state`, which carries the identical code — deliberately not done here so the three demoshops currently validated against that pin are not invalidated mid-review.
